### PR TITLE
Command-line version of the experiment scripts + log + tests

### DIFF
--- a/experiment/template/eVOLVER_module.py
+++ b/experiment/template/eVOLVER_module.py
@@ -1,17 +1,18 @@
 import socket
 import os.path
+import logging
 import shutil
 import time
 import pickle
 import numpy as np
 import numpy.matlib
-import matplotlib
 import scipy.signal
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 from socketIO_client import SocketIO, BaseNamespace
 from threading import Thread
 import asyncio
+
+# logger set up
+logger = logging.getLogger(__name__)
 
 plt.ioff()
 
@@ -27,7 +28,7 @@ shared_port = None
 
 # TODO: use proper async/await
 wait_for_data = True
-control = np.power(2,range(0,32))
+control = np.power(2, range(0,32))
 current_chemo = [0] * 16
 current_temps = [0] * 16
 connected = False
@@ -36,17 +37,20 @@ class EvolverNamespace(BaseNamespace):
     def on_connect(self, *args):
         global connected, current_temps
         print("Connected to eVOLVER as client")
+        logger.info('connected to eVOLVER as client')
         connected = True
 
     def on_disconnect(self, *args):
         global connected
         print("Disconected from eVOLVER as client")
+        logger.info('disconnected to eVOLVER as client')
         connected = False
 
     def on_reconnect(self, *args):
         global connected, stop_waiting, current_temps
         current_temps = [0] * 16
         print("Reconnected to eVOLVER as client")
+        logger.info("reconnected to eVOLVER as client")
         connected = True
         stop_waiting = True
 
@@ -55,6 +59,7 @@ class EvolverNamespace(BaseNamespace):
         global received_data, wait_for_data
         received_data = data
         wait_for_data = False
+        logger.debug("data response: %s" % data)
 
     def on_calibrationod(self, data):
         global od_cal, save_path, shared_name
@@ -62,6 +67,7 @@ class EvolverNamespace(BaseNamespace):
         with open(file_path, 'w') as f:
             f.write(data)
         od_cal = True
+        logger.debug("OD calibration: %s" % data)
 
     def on_calibrationtemp(self, data):
         global temp_cal, save_path, shared_name
@@ -69,9 +75,11 @@ class EvolverNamespace(BaseNamespace):
         with open(file_path , 'w') as f:
             f.write(data)
         temp_cal = True
+        logger.debug("temperature calibration: %s" % data)
 
 def read_data(vials, exp_name):
-    global wait_for_data, received_data, current_temps, connected, stop_waiting, shared_ip, shared_port
+    global wait_for_data, received_data, current_temps, connected
+    global stop_waiting, shared_ip, shared_port
 
     save_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -83,21 +91,27 @@ def read_data(vials, exp_name):
 
     wait_for_data = True
     stop_waiting = False
-    dpu_evolver_ns.emit('data', {'config':{'od':[2500] * 16, 'temp':['NaN'] * 16}}, namespace='/dpu-evolver')
+    logger.debug('requesting data from eVOLVER')
+    dpu_evolver_ns.emit('data', {'config':{'od':[2125] * 16,
+                                           'temp':['NaN'] * 16}},
+                        namespace='/dpu-evolver')
     start_time = time.time()
     # print('Fetching data from eVOLVER')
     while(wait_for_data):
-        if not connected or stop_waiting or (time.time() - start_time > 30):
+        if not connected or stop_waiting or (time.time() - start_time > 60):
             wait_for_data = False
-            print('Issue with eVOLVER communication - skipping data acquisition')
+            print('Issue with eVOLVER communication - '
+                  'skipping data acquisition')
+            logger.warning('issue with eVOLVER communication, skipping data '
+                           'acquisition')
             return None, None
         pass
-
 
     od_data = received_data['od']
     temp_data = received_data['temp']
     if 'NaN' in od_data or 'NaN' in temp_data:
         print('NaN recieved, Error with measurement')
+        logger.error('NaN received, error with measurements')
         return None, None
     temps = []
     for x in vials:
@@ -110,16 +124,28 @@ def read_data(vials, exp_name):
 
         try:
             if (od_cal.shape[0] == 4):
-                od_data[x] = np.real(od_cal[2,x] - ((np.log10((od_cal[1,x]-od_cal[0,x])/(float(od_data[x]) - od_cal[0,x])-1))/od_cal[3,x]))
+                od_data[x] = np.real(od_cal[2,x] -
+                                     ((np.log10((od_cal[1,x] -
+                                                 od_cal[0,x]) /
+                                                (float(od_data[x]) -
+                                                 od_cal[0,x]) - 1)) /
+                                                od_cal[3,x]))
+                logger.debug('OD from vial %d: %.3f' % (x, od_data[x]))
         except ValueError:
             print("OD Read Error")
+            logger.error('OD read error for vial %d, setting to NaN' % x)
             od_data[x] = 'NaN'
         try:
-            temp_data[x] = (float(temp_data[x]) * temp_cal[0][x]) + temp_cal[1][x]
+            temp_data[x] = (float(temp_data[x]) *
+                            temp_cal[0][x]) + temp_cal[1][x]
+            logger.debug('temperature from vial %d: %.3f' % (x, temp_data[x]))
         except ValueError:
             print("Temp Read Error")
+            logger.error('temperature read error for vial %d, setting to NaN'
+                         % x)
             temp_data[x]  = 'NaN'
     if not temps == current_temps:
+        logger.debug('updating temperatures to %s' % list(temps))
         MESSAGE = list(temps)
         command = {'param':'temp', 'message':MESSAGE}
         dpu_evolver_ns.emit('command', command, namespace='/dpu-evolver')
@@ -127,8 +153,10 @@ def read_data(vials, exp_name):
 
     return od_data, temp_data
 
-def fluid_command(MESSAGE, vial, elapsed_time, pump_wait, exp_name, time_on, file_write):
-    command = {'param':'pump', 'message':MESSAGE}
+def fluid_command(MESSAGE, vial, elapsed_time, pump_wait, exp_name, time_on,
+                  file_write):
+    logger.debug('fluid command: %s' % MESSAGE)
+    command = {'param': 'pump', 'message': MESSAGE}
     dpu_evolver_ns.emit('command', command, namespace='/dpu-evolver')
 
     save_path = os.path.dirname(os.path.realpath(__file__))
@@ -155,18 +183,25 @@ def update_chemo(vials, exp_name, bolus_in_s, control):
         chemo_set = data[len(data)-1][2]
         if not chemo_set == current_chemo[x]:
             current_chemo[x] = chemo_set
-            MESSAGE = {'pumps_binary':"{0:b}".format(control[x]), 'pump_time': bolus_in_s[x], 'efflux_pump_time': bolus_in_s[x] * 2, 'delay_interval': chemo_set, 'times_to_repeat': -1, 'run_efflux': 1}
+            MESSAGE = {'pumps_binary':"{0:b}".format(control[x]),
+                       'pump_time': bolus_in_s[x],
+                       'efflux_pump_time': bolus_in_s[x] * 2,
+                       'delay_interval': chemo_set,
+                       'times_to_repeat': -1, 'run_efflux': 1}
+            logger.debug('updating chemostat for pump %d: %s' % (x, MESSAGE))
             command = {'param': 'pump', 'message': MESSAGE}
             dpu_evolver_ns.emit('command', command, namespace = '/dpu-evolver')
 
 def stir_rate (MESSAGE):
     command = {'param':'stir', 'message':MESSAGE}
+    logger.debug('stir rate command: %s' % MESSAGE)
     dpu_evolver_ns.emit('command', command, namespace='/dpu-evolver')
 
 def parse_data(data, elapsed_time, vials, exp_name, parameter):
     save_path = os.path.dirname(os.path.realpath(__file__))
     if data == 'empty':
         print("%s Data Empty! Skipping data log...".format(parameter))
+        logger.warning('%s data empty! Skipping data log...' % parameter)
     else:
         for x in vials:
             file_name =  "vial{0}_{1}.txt".format(x, parameter)
@@ -176,16 +211,20 @@ def parse_data(data, elapsed_time, vials, exp_name, parameter):
             text_file.close()
 
 def start_background_loop(loop):
+    logger.debug('starting background loop')
     asyncio.set_event_loop(loop)
     loop.run_forever()
 
 def run(evolver_ip, evolver_port):
+    logger.debug('run function')
     global dpu_evolver_ns
     socketIO = SocketIO(evolver_ip, evolver_port)
     dpu_evolver_ns = socketIO.define(EvolverNamespace, '/dpu-evolver')
     socketIO.wait()
 
-def initialize_exp(exp_name, vials, evolver_ip, evolver_port):
+def initialize_exp(exp_name, vials, evolver_ip, evolver_port,
+                   always_yes=False):
+    logger.debug('initializing experiment')
     global od_cal, temp_cal, shared_name, shared_ip, shared_port
     shared_name = exp_name
     shared_ip = evolver_ip
@@ -198,17 +237,20 @@ def initialize_exp(exp_name, vials, evolver_ip, evolver_port):
 
     if dpu_evolver_ns is None:
         print("Waiting for evolver connection...")
+        logger.info('waiting for eVOLVER connection')
 
     save_path = os.path.dirname(os.path.realpath(__file__))
     dir_path = os.path.join(save_path,exp_name)
-
-
 
     while dpu_evolver_ns is None:
         pass
 
     if os.path.exists(dir_path):
-        exp_continue = input('Continue from existing experiment? (y/n): ')
+        logger.info('found an existing experiment')
+        if always_yes:
+            exp_continue = 'y'
+        else:
+            exp_continue = input('Continue from existing experiment? (y/n): ')
     else:
         exp_continue = 'n'
 
@@ -216,25 +258,37 @@ def initialize_exp(exp_name, vials, evolver_ip, evolver_port):
 
         start_time = time.time()
         if os.path.exists(dir_path):
-            exp_overwrite = input('Directory aleady exists. Overwrite with new experiment? (y/n): ')
+            if always_yes:
+                exp_overwrite = 'y'
+            else:
+                exp_overwrite = input('Directory aleady exists. '
+                                      'Overwrite with new experiment? (y/n): ')
+            logger.info('data directory already exists')
             if exp_overwrite == 'y':
+                logger.info('deleting existing data directory')
                 shutil.rmtree(dir_path)
             else:
-                print('Change experiment name in custom_script.py and then restart...')
+                print('Change experiment name in custom_script.py '
+                      'and then restart...')
+                logger.warning('not deleting existing data directory, exiting')
                 exit() #exit
 
-        os.makedirs(os.path.join(dir_path,'OD'))
-        os.makedirs(os.path.join(dir_path,'temp'))
-        os.makedirs(os.path.join(dir_path,'pump_log'))
-        os.makedirs(os.path.join(dir_path,'temp_config'))
-        os.makedirs(os.path.join(dir_path,'ODset'))
-        os.makedirs(os.path.join(dir_path,'chemo_config'))
+        logger.debug('creating data directories')
+        os.makedirs(os.path.join(dir_path, 'OD'))
+        os.makedirs(os.path.join(dir_path, 'temp'))
+        os.makedirs(os.path.join(dir_path, 'pump_log'))
+        os.makedirs(os.path.join(dir_path, 'temp_config'))
+        os.makedirs(os.path.join(dir_path, 'ODset'))
+        os.makedirs(os.path.join(dir_path, 'chemo_config'))
 
+        logger.debug('requesting OD calibrations')
         dpu_evolver_ns.emit('getcalibrationod', {}, namespace = '/dpu-evolver')
         while od_cal is None:
             pass
 
-        dpu_evolver_ns.emit('getcalibrationtemp', {}, namespace = '/dpu-evolver')
+        logger.debug('requesting temperature calibrations')
+        dpu_evolver_ns.emit('getcalibrationtemp',
+                            {}, namespace = '/dpu-evolver')
         while temp_cal is None:
             pass
 
@@ -242,7 +296,9 @@ def initialize_exp(exp_name, vials, evolver_ip, evolver_port):
             file_name =  "vial{0}_OD.txt".format(x)
             file_path = os.path.join(dir_path,'OD',file_name)
             text_file = open(file_path,"w")
-            text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name, x, time.strftime("%c")))
+            text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name,
+                                                                     x,
+                                                          time.strftime("%c")))
             text_file.close()
 
             file_name =  "vial{0}_temp.txt".format(x)
@@ -252,21 +308,27 @@ def initialize_exp(exp_name, vials, evolver_ip, evolver_port):
             file_name =  "vial{0}_tempconfig.txt".format(x)
             file_path = os.path.join(dir_path,'temp_config',file_name)
             text_file = open(file_path,"w")
-            text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name, x, time.strftime("%c")))
+            text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name,
+                                                                     x,
+                                                          time.strftime("%c")))
             text_file.write("0,0\n")
             text_file.close()
 
             file_name =  "vial{0}_pump_log.txt".format(x)
             file_path = os.path.join(dir_path,'pump_log',file_name)
             text_file = open(file_path,"w")
-            text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name, x, time.strftime("%c")))
+            text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name,
+                                                                     x,
+                                                          time.strftime("%c")))
             text_file.write("0,0\n")
             text_file.close()
 
             file_name =  "vial{0}_ODset.txt".format(x)
             file_path = os.path.join(dir_path,'ODset',file_name)
             text_file = open(file_path,"w")
-            text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name, x, time.strftime("%c")))
+            text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name,
+                                                                     x,
+                                                          time.strftime("%c")))
             text_file.write("0,0\n")
             text_file.close()
 
@@ -280,17 +342,23 @@ def initialize_exp(exp_name, vials, evolver_ip, evolver_port):
         OD_read = None
         temp_read = None
         print('Getting initial values from eVOLVER...')
+        logger.info('getting initial values from eVOLVER')
         while OD_read is None and temp_read is None:
             OD_read, temp_read  = read_data(vials, exp_name)
-            exp_blank = input('Calibrate vials to blank? (y/n): ')
+            if always_yes:
+                exp_blank = 'y'
+            else:
+                exp_blank = input('Calibrate vials to blank? (y/n): ')
             if exp_blank == 'y':
                 OD_initial = OD_read
+                logger.info('using initial OD measurement as blank')
             else:
                 OD_initial = np.zeros(len(vials))
 
     else:
         pickle_name =  "{0}.pickle".format(exp_name)
-        pickle_path = os.path.join(save_path,exp_name,pickle_name)
+        pickle_path = os.path.join(save_path, exp_name, pickle_name)
+        logger.info('loading previous experiment data: %s' % pickle_path)
         with open(pickle_path, 'rb') as f:
             loaded_var  = pickle.load(f)
         x = loaded_var
@@ -303,6 +371,7 @@ def initialize_exp(exp_name, vials, evolver_ip, evolver_port):
     return start_time, OD_initial
 
 def stop_all_pumps():
+    logger.warning('stopping all pumps')
     command = {'param':'pump', 'message':'stop'}
     dpu_evolver_ns.emit('command', command, namespace='/dpu-evolver')
     print('All Pumps Stopped!')
@@ -311,10 +380,12 @@ def save_var(exp_name, start_time, OD_initial):
     save_path = os.path.dirname(os.path.realpath(__file__))
     pickle_name =  "{0}.pickle".format(exp_name)
     pickle_path = os.path.join(save_path,exp_name,pickle_name)
+    logger.debug('saving all variables: %s' % pickle_path)
     with open(pickle_path, 'wb') as f:
         pickle.dump([start_time, OD_initial], f)
 
 def restart_chemo():
+    logger.debug('restarting chemostat')
     global current_chemo
     current_chemo = [0] * 16
 

--- a/experiment/template/eVOLVER_module.py
+++ b/experiment/template/eVOLVER_module.py
@@ -14,8 +14,6 @@ import asyncio
 # logger set up
 logger = logging.getLogger(__name__)
 
-plt.ioff()
-
 dpu_evolver_ns = None
 received_data = {}
 od_cal = None

--- a/experiment/template/main_eVOLVER.py
+++ b/experiment/template/main_eVOLVER.py
@@ -1,99 +1,135 @@
-from tkinter import *
-from tkinter.ttk import *
-import eVOLVER_module
+#!/usr/bin/env python3
+
 import time
-import pickle
 import os.path
+import logging
+import argparse
+import eVOLVER_module
 import custom_script
-import smtplib
 
-#### Where the GUI is called and widgets are placed
-class make_GUI:
+logger = logging.getLogger('main')
 
-    def __init__(self, master):
+def get_options():
+    description = 'Run an eVOLVER experiment from the command line'
+    parser = argparse.ArgumentParser(description=description)
 
-        master.wm_title("eVOLVER Test")
-        note = Notebook(master)
-        home = Frame(note)
-        note.add(home, text = "Home")
+    parser.add_argument('--always-yes', action='store_true',
+                        default=False,
+                        help='Answer yes to all questions '
+                             '(i.e. continues from existing experiment, '
+                             'overwrites existing data and blanks OD '
+                             'measurements)')
+    parser.add_argument('--log-path',
+                        default='evolver.log',
+                        help='Path to the log file (default: %(default)s)')
 
-        save_path = os.path.dirname(os.path.realpath(__file__))
-        tabArray = [ ]
+    log_nolog = parser.add_mutually_exclusive_group()
+    log_nolog.add_argument('--verbose', action='count',
+                           default=0,
+                           help='Increase logging verbosity level to DEBUG '
+                                '(default: INFO)')
+    log_nolog.add_argument('--quiet', action='store_true',
+                           default=False,
+                           help='Disable logging to file entirely')
 
-        for x in vials:
-            newTab = Frame(note)
-            note.add(newTab, text = "{0}".format(x))
-            tabArray.append(newTab)
+    return parser.parse_args()
 
-        self.quitButton = Button(home, text="Stop Measuring", command=stop_exp)
-        self.quitButton.pack(side=BOTTOM)
-
-        self.printButton = Button(home, text="Start/ Measure now", command=start_exp)
-        self.printButton.pack(side=BOTTOM)
-
-        note.pack(fill=BOTH, expand=YES)
-
-
-## Task done by pressing printButton
 def start_exp():
     stop_exp()
+    logger.info('starting/restarting experiment')
     eVOLVER_module.restart_chemo()
     update_eVOLVER()
 
 def stop_exp():
-    global run_exp
-    try:
-        run_exp
-    except NameError:
-        print("Name Error")
-    else:
-        print("Experiment Stopped!")
-        root.after_cancel(run_exp)
-    #stop all pumps, including chemostat commands
+    logger.info('stopping all pumps')
+    # stop all pumps, including chemostat commands
     eVOLVER_module.stop_all_pumps()
 
-#### Updates Temperature and OD values (repeated every 10 seconds)
 def update_eVOLVER():
+    logger.debug('updating eVOLVER')
     global OD_data, temp_data
-    ##Read and record OD
+    # read and record OD
     elapsed_time = round((time.time() - start_time)/3600,4)
+    logger.debug('elapsed time: %.4f hours' % elapsed_time)
     print("Time: {0} Hours".format(elapsed_time))
     OD_data, temp_data = eVOLVER_module.read_data(vials, exp_name)
-    skip = False
     if OD_data is not None and temp_data is not None:
         if OD_data == 'empty':
             print("Data Empty! Skipping data log...")
+            logger.warning('empty OD data received! Skipping data log...')
         else:
             for x in vials:
                 OD_data[x] = OD_data[x] - OD_initial[x]
-        eVOLVER_module.parse_data(OD_data, elapsed_time,vials,exp_name, 'OD')
-        eVOLVER_module.parse_data(temp_data, elapsed_time,vials,exp_name, 'temp')
+        eVOLVER_module.parse_data(OD_data, elapsed_time,
+                                  vials,exp_name, 'OD')
+        eVOLVER_module.parse_data(temp_data, elapsed_time,
+                                  vials,exp_name, 'temp')
 
-        ##Make decision
+        # make decision
         custom_functions(elapsed_time,exp_name)
 
-        #Save Variables
-        global run_exp
+        # save Variables
         eVOLVER_module.save_var(exp_name, start_time, OD_initial)
-    run_exp = root.after(1000,update_eVOLVER)
 
-
-#### Custom Script
 def custom_functions(elapsed_time, exp_name):
     global OD_data, temp_data
     if OD_data == 'empty':
         print("UDP Empty, did not execute program!")
+        logger.warning('empty OD data received! Skipping custom routine...')
     else:
-        ###load script from another python file
-        custom_script.test(OD_data, temp_data, vials, elapsed_time, exp_name)
+        # load user script from custom_script.py
+        custom_script.user_routine(OD_data, temp_data, vials,
+                                   elapsed_time, exp_name)
 
-
-#### Runs if this is main script
 if __name__ == '__main__':
+    options = get_options()
+
+    # logging setup
+    if options.quiet:
+        logging.basicConfig(level=logging.CRITICAL + 10)
+    else:
+        if options.verbose == 0:
+            level = logging.INFO
+        elif options.verbose >= 1:
+            level = logging.DEBUG
+        logging.basicConfig(format='%(asctime)s - %(name)s - [%(levelname)s] '
+                            '- %(message)s',
+                            datefmt='%Y-%m-%d %H:%M:%S',
+                            filename=options.log_path,
+                            level=level)
+
     exp_name, evolver_ip, evolver_port = custom_script.choose_name()
     vials = range(0,16)
-    start_time, OD_initial  =  eVOLVER_module.initialize_exp(exp_name, vials, evolver_ip, evolver_port)
-    root=Tk()
-    make_GUI(root)
-    update_eVOLVER()
-    root.mainloop()
+    logger.info('experiment parameters: %s, %s, %s' % (exp_name,
+                                                       evolver_ip,
+                                                       evolver_port))
+    start_time, OD_initial = eVOLVER_module.initialize_exp(exp_name, vials,
+                                                           evolver_ip,
+                                                           evolver_port,
+                                                 always_yes=options.always_yes)
+    loop_start = time.time()
+    while True:
+        try:
+            # run update if at least a 10th of second has passed
+            loop_time = time.time()
+            if loop_time - loop_start >= 0.1:
+                update_eVOLVER()
+                loop_start = time.time()
+        except KeyboardInterrupt:
+            try:
+                print('Ctrl-C detected, pausing experiment')
+                logger.warning('interrupt received, pausing experiment')
+                stop_exp()
+                while True:
+                    key = input('Experiment paused. Press any key to restart '
+                                ' or hit Ctrl-C again to terminate experiment')
+                    logger.warning('resuming experiment')
+                    break
+            except KeyboardInterrupt:
+                print('Second Ctrl-C detected, shutting down')
+                logger.warning('second interrupt received, terminating '
+                               'experiment')
+                stop_exp()
+                print('Experiment stopped, goodbye!')
+                logger.warning('experiment stopped, goodbye!')
+                break

--- a/experiment/template/main_eVOLVER.py
+++ b/experiment/template/main_eVOLVER.py
@@ -133,3 +133,6 @@ if __name__ == '__main__':
                 print('Experiment stopped, goodbye!')
                 logger.warning('experiment stopped, goodbye!')
                 break
+        except Exception as e:
+            logger.critical('exception %s stopped the experiment' % str(e))
+            break

--- a/experiment/template/test_eVOLVER.py
+++ b/experiment/template/test_eVOLVER.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import logging
+import argparse
+import numpy as np
+from unittest import mock
+import eVOLVER_module
+import main_eVOLVER
+import custom_script
+
+eVOLVER_module.initialize_exp = mock.Mock()
+eVOLVER_module.initialize_exp.return_value = 0.0, None
+eVOLVER_module.fluid_command = mock.Mock()
+eVOLVER_module.update_chemo = mock.Mock()
+eVOLVER_module.stir_rate = mock.Mock()
+
+logger = logging.getLogger('test')
+
+def update_eVOLVER(OD_data, temp_data, elapsed_time, vials):
+    logger.debug('elapsed time: %.4f hours' % elapsed_time)
+    print("Time: {0} Hours".format(elapsed_time))
+
+    if OD_data is not None and temp_data is not None:
+        eVOLVER_module.parse_data(OD_data, elapsed_time,
+                                  vials, exp_name, 'OD')
+        eVOLVER_module.parse_data(temp_data, elapsed_time,
+                                  vials, exp_name, 'temp')
+
+        main_eVOLVER.OD_data = OD_data
+        main_eVOLVER.temp_data = temp_data
+
+        # make decision
+        main_eVOLVER.custom_functions(elapsed_time, main_eVOLVER.exp_name)
+
+        # save Variables
+        eVOLVER_module.save_var(main_eVOLVER.exp_name,
+                                main_eVOLVER.start_time,
+                                np.zeros(len(vials)))
+
+def get_options():
+    description = 'Run a mock eVOLVER experiment from the command line'
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument('mock',
+                        help='Path to test data (same directory format, '
+                             'can be either a previous experiment or '
+                             'generated data)')
+
+    parser.add_argument('--vials',
+                        type=int,
+                        default=range(0, 16),
+                        nargs='+',
+                        help='Vials to run the tests on (default: 0-15)')
+    parser.add_argument('--log-path',
+                        default='evolver_test.log',
+                        help='Path to the log file (default: %(default)s)')
+
+    log_nolog = parser.add_mutually_exclusive_group()
+    log_nolog.add_argument('--verbose', action='count',
+                           default=0,
+                           help='Increase logging verbosity level to DEBUG '
+                                '(default: INFO)')
+    log_nolog.add_argument('--quiet', action='store_true',
+                           default=False,
+                           help='Disable logging to file entirely')
+
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    options = get_options()
+
+    # logging setup
+    if options.quiet:
+        logging.basicConfig(level=logging.CRITICAL + 10)
+    else:
+        if options.verbose == 0:
+            level = logging.INFO
+        elif options.verbose >= 1:
+            level = logging.DEBUG
+        logging.basicConfig(format='%(asctime)s - %(name)s - [%(levelname)s] '
+                            '- %(message)s',
+                            datefmt='%Y-%m-%d %H:%M:%S',
+                            filename=options.log_path,
+                            level=level)
+
+    exp_name, evolver_ip, evolver_port = custom_script.choose_name()
+    vials = options.vials
+    start_time, OD_initial = eVOLVER_module.initialize_exp(exp_name, vials,
+                                                           evolver_ip,
+                                                           evolver_port)
+    main_eVOLVER.start_time = start_time
+    main_eVOLVER.vials = options.vials
+    main_eVOLVER.exp_name = exp_name
+
+    # read mock data
+    od_data_all = {}
+    temp_data_all = {}
+    for x in vials:
+        file_name =  "vial{0}_OD.txt".format(x)
+        od_path = os.path.join(options.mock, 'OD', file_name)
+        od_data_all[x] = np.genfromtxt(od_path, delimiter=',')
+        file_name =  "vial{0}_temp.txt".format(x)
+        temp_path = os.path.join(options.mock, 'temp', file_name)
+        temp_data_all[x] = np.genfromtxt(temp_path, delimiter=',')
+    # keep track of the timepoints to use
+    times = set()
+    for x in vials:
+        times = times.union(od_data_all[x][:, 0])
+        times = times.union(temp_data_all[x][:, 0])
+
+    # create output directory
+    save_path = os.path.dirname(os.path.realpath(__file__))
+    dir_path = os.path.join(save_path, exp_name)
+    if os.path.exists(dir_path):
+        print('Please delete the old output directory (%s) and restart' %
+              dir_path)
+        logger.error('output directory %s exists already, exiting' %
+                     dir_path)
+        sys.exit(1)
+
+    logger.debug('creating data directories')
+    os.makedirs(os.path.join(dir_path, 'OD'))
+    os.makedirs(os.path.join(dir_path, 'temp'))
+    os.makedirs(os.path.join(dir_path, 'pump_log'))
+    os.makedirs(os.path.join(dir_path, 'temp_config'))
+    os.makedirs(os.path.join(dir_path, 'ODset'))
+    os.makedirs(os.path.join(dir_path, 'chemo_config'))
+    for x in vials:
+        file_name =  "vial{0}_OD.txt".format(x)
+        file_path = os.path.join(dir_path,'OD',file_name)
+        text_file = open(file_path,"w")
+        text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name,
+                                                                    x,
+                                                        time.strftime("%c")))
+        text_file.close()
+
+        file_name =  "vial{0}_temp.txt".format(x)
+        file_path = os.path.join(dir_path,'temp',file_name)
+        text_file = open(file_path,"w").close()
+
+        file_name =  "vial{0}_tempconfig.txt".format(x)
+        file_path = os.path.join(dir_path,'temp_config',file_name)
+        text_file = open(file_path,"w")
+        text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name,
+                                                                    x,
+                                                        time.strftime("%c")))
+        text_file.write("0,0\n")
+        text_file.close()
+
+        file_name =  "vial{0}_pump_log.txt".format(x)
+        file_path = os.path.join(dir_path,'pump_log',file_name)
+        text_file = open(file_path,"w")
+        text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name,
+                                                                    x,
+                                                        time.strftime("%c")))
+        text_file.write("0,0\n")
+        text_file.close()
+
+        file_name =  "vial{0}_ODset.txt".format(x)
+        file_path = os.path.join(dir_path,'ODset',file_name)
+        text_file = open(file_path,"w")
+        text_file.write("Experiment: {0} vial {1}, {2}\n".format(exp_name,
+                                                                    x,
+                                                        time.strftime("%c")))
+        text_file.write("0,0\n")
+        text_file.close()
+
+        file_name =  "vial{0}_chemoconfig.txt".format(x)
+        file_path = os.path.join(dir_path,'chemo_config',file_name)
+        text_file = open(file_path,"w")
+        text_file.write("0,0,0\n")
+        text_file.write("0,0,0\n")
+        text_file.close()
+
+    for time in sorted([float(x) for x in times if str(x) != 'nan']):
+        OD_data = np.empty(len(vials)) * np.nan
+        temp_data = np.empty(len(vials)) * np.nan
+
+        for x in vials:
+            # do we have this timepoint for this vial?
+            data = od_data_all[x]
+            tpoint = data[data[:, 0] == time]
+            if tpoint.shape[0] > 0:
+                # we consider only the first matching timepoint
+                OD_data[x] = tpoint[0, 1]
+            data = temp_data_all[x]
+            tpoint = data[data[:, 0] == time]
+            if tpoint.shape[0] > 0:
+                # we consider only the first matching timepoint
+                temp_data[x] = tpoint[0, 1]
+
+        update_eVOLVER(OD_data, temp_data, time, vials)


### PR DESCRIPTION
Removed the GUI, now an experiment can be paused hitting Ctrl+C in the command line; hitting any key after that resumes the experiment, hitting Ctrl-C a second time stops it

Also added logging messages to a file, with an option to modulate verbosity, the name of the log file and an option to disable it entirely

Slightly refactored the custom_script.py file so that the users can pick the function relevant to them by just uncommenting a line

Also added a few command line options to make it easier to run from the command line

```
$ python3 main_eVOLVER.py -h
usage: main_eVOLVER.py [-h] [--always-yes] [--log-path LOG_PATH]
                       [--verbose | --quiet]

Run an eVOLVER experiment from the command line

optional arguments:
  -h, --help           show this help message and exit
  --always-yes         Answer yes to all questions (i.e. continues from
                       existing experiment, overwrites existing data and
                       blanks OD measurements)
  --log-path LOG_PATH  Path to the log file (default: evolver.log)
  --verbose            Increase logging verbosity level to DEBUG (default:
                       INFO)
  --quiet              Disable logging to file entirely
```

TODO: remove unused imports