### PR TITLE
Avoid concurrent broadcast events (when pausing and with slow hardware)

### DIFF
--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -542,10 +542,20 @@ if __name__ == '__main__':
                             filename=options.log_name,
                             level=level)
 
+    reset_connection_timer = time.time()
     while True:
         try:
             # infinite loop
-            socketIO.wait()
+            socketIO.wait(seconds=0.1)
+            if time.time() - reset_connection_timer > 3600:
+                # reset connection to avoid buildup of broadcast
+                # messages (unlikely but could happen for very long
+                # experiments with slow dpu code/computer)
+                logger.info('resetting connection to eVOLVER to avoid '
+                            'potential buildup of broadcast messages')
+                socketIO.disconnect()
+                socketIO.connect()
+                reset_connection_timer = time.time()
         except KeyboardInterrupt:
             try:
                 print('Ctrl-C detected, pausing experiment')

--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -551,12 +551,15 @@ if __name__ == '__main__':
                 print('Ctrl-C detected, pausing experiment')
                 logger.warning('interrupt received, pausing experiment')
                 EVOLVER_NS.stop_exp()
+                # stop receiving broadcasts
+                socketIO.disconnect()
                 while True:
                     key = input('Experiment paused. Press enter key to restart '
                                 ' or hit Ctrl-C again to terminate experiment')
                     logger.warning('resuming experiment')
                     # no need to have something like "restart_chemo" here
                     # with the new server logic
+                    socketIO.connect()
                     break
             except KeyboardInterrupt:
                 print('Second Ctrl-C detected, shutting down')
@@ -576,4 +579,5 @@ if __name__ == '__main__':
 
     # stop experiment one last time
     # covers corner case where user presses Ctrl-C twice quickly
+    socketIO.connect()
     EVOLVER_NS.stop_exp()


### PR DESCRIPTION
# What? Why?

When pausing for a long period of time there is a significant risk
of triggering multiple backlogged broadcasts messages once the
script is unpaused. This change disconnects the socket when pausing
so that no broadcast is received while pausing.

Tested in an actual eVOLVER

# Checks
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).