### PR TITLE
Calibration generalization

### DIFF
--- a/calibration/calibrate.py
+++ b/calibration/calibrate.py
@@ -14,12 +14,12 @@ from mpl_toolkits.mplot3d import Axes3D
 from matplotlib import cm
 from matplotlib.ticker import LinearLocator, FormatStrFormatter
 
-cal_received = False
-raw_calibration = None
+VALID_FIT_TYPES = ['sigmoid', 'linear', 'constant', '3d']
+
+data_received = False
+calibration = None
 input_data = None
 dpu_evolver_ns = None
-odpower = None
-odaxis = None
 
 class EvolverNamespace(BaseNamespace):
     def on_connect(self, *args):
@@ -38,152 +38,96 @@ class EvolverNamespace(BaseNamespace):
         connected = True
         stop_waiting = True
 
-    def on_calibrationrawod(self, data):
-        global cal_received, raw_calibration, input_data
-        input_data = data['inputData']
-        raw_calibration = parse_od_cal_data(data)
-        cal_received = True
+    def on_calibration(self, data):
+        global data_received, calibration, input_data
+        calibration = data
+        data_received = True
 
-    def on_calibrationrawtemp(self, data):
-        global cal_received, raw_calibration, input_data
-        raw_calibration = parse_temp_cal_data(data)
-        cal_received = True
-
-    def on_odfilenames(self, data):
-        global cal_received
-        for f in data:
-            print(f)
-        cal_received = True
-
-    def on_tempfilenames(self, data):
-        global cal_received
-        for f in data:
-            print(f)
-        cal_received = True
-
-def SurfacePlot(func, data, fittedParameters, i, fig):
-    x_data = data[0]
-    y_data = data[1]
-    z_data = data[2]
-
-    xModel = np.linspace(min(x_data), max(x_data), 20)
-    yModel = np.linspace(min(y_data), max(y_data), 20)
-    X, Y = np.meshgrid(xModel, yModel)
-
-    Z = func(np.array([X, Y]), *fittedParameters)
-
-    ax = fig.add_subplot(4,4, i + 1, projection = '3d')
-
-    ax.plot_surface(X, Y, Z, rstride=1, cstride=1, linewidth=1, antialiased=True, alpha=0.5)
-
-    ax.scatter(x_data, y_data, z_data, c='r', s=10) # show data along with plotted surface
-
-    ax.set_title('Surface Plot (click-drag with mouse)') # add a title for surface plot
-    ax.set_xlabel('X Data') # X axis data label
-    ax.set_ylabel('Y Data') # Y axis data label
-    ax.set_zlabel('Z Data') # Z axis data label
-
-def parse_od_cal_data(data):
-    cal_ods = {'od90': [0] * 16, 'od135': [0] * 16, 'temp':[0] * 16}
-    vial_datas = data['vialData']
-
-    for param, param_vial_datas in vial_datas.items():
-        for i, vial_data in enumerate(param_vial_datas):
-            cal_ods[param][i] = [0] * 16
-            for j in range(16):
-                # Shift indexes to handle rotation of vials
-                index_change = -j + i
-                cal_ods[param][i][j] = vial_data[index_change]
-    return cal_ods
-
-def parse_temp_cal_data(data):
-    return data['vialData']
+    def on_calibrationnames(self, data):
+        global data_received
+        for calibration_name in data:
+            print(calibration_name)
+        data_received = True
 
 def sigmoid(x, a, b, c, d):
-    y = a + (b - a)/(1 + (10**((c-x)*d)))
-    return y
+    return a + (b - a)/(1 + (10**((c-x)*d)))
 
 def linear(x, a, b):
-    y = np.array(x)*a + b
-    return y
+    return np.array(x)*a + b
 
-def three_dim(data, c0,c1,c2,c3,c4,c5):
+def three_dim(data, c0, c1, c2, c3, c4, c5):
     x = data[0]
     y = data[1]
     return c0 + c1*x + c2*y + c3*x**2 + c4*x*y + c5*y**2
 
-def fit(x, y):
-    #Fits the data to a sigmoid and returns the parameters
-    xdata = np.array(x)
-    ydata = np.array(y)
+def sigmoid_fit(calibration, fit_name, params, graph = True):
+    coefficients = []
 
-    paramsig, pcovsig = curve_fit(sigmoid, xdata, ydata, p0 = [62721, 62721, 0, -1], maxfev = 10000000)
-    paramlin, pcovlin = curve_fit(linear, xdata, ydata, p0 = [-8750, 62721])
-    return paramsig, paramlin;
-
-def residuals(curve_y, real_y):
-    #Calculates residuals using the least square method
-    curve_arr = np.array(curve_y)
-    real_arr = np.array(real_y)
-    res = (curve_arr - real_arr)**2
-    sumsquare = res.sum()
-    return sumsquare
-
-def calibrate_od(calibration_data, graph_name, param, graph = False):
-    global input_data
-    paramlist = []
-    if graph:
-        fig1, ax = plt.subplots(4, 4)
-        fig1.suptitle('File Name: ' + graph_name)
-
-    for m in range(16):
-        raw_ods = []
-        stds = []
-        for raw_od in calibration_data[param][m]:
-            raw_ods.append(np.median(raw_od))
-            stds.append(np.std(raw_od))
-
-        paramsig, paramlin = fit(input_data,raw_ods)
-        paramlist.append(np.array(paramsig).tolist())
-        if graph == True:
-            ax[m//4, (m % 4)].plot(input_data, raw_ods, 'o', markersize=1.5, color='black')
-            ax[m//4, (m % 4)].plot(np.linspace(0, max(input_data), 500), sigmoid(np.linspace(0, max(input_data), 500), *paramsig), markersize = 1.5, label=None)
-            ax[m//4, (m % 4)].errorbar(input_data, raw_ods, yerr=stds, fmt='none')
-            ax[m//4, (m % 4)].set_title('Vial: ' + str(m))
-            ax[m//4, (m % 4)].ticklabel_format(style='sci', axis='y', scilimits=(0,0))
-
-    if graph:
-        plt.subplots_adjust(hspace = 0.6)
-        plt.show()
-    return paramlist
-
-
-def calibrate3d_od(calibration_data, graph_name, graph= False):
-    global input_data
-
-    initial_parameters = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-
-    paramlist = []
-
-    if graph:
-        fig1 = plt.figure()
-        fig1.suptitle('File Name: ' + graph_name)
+    # For single param calibrations, just take the first value from the returned dictionary
+    calibration_data = list(process_vial_data(calibration, param = params[0]).values())[0]
+    medians = calibration_data["medians"]
+    standard_deviations = calibration_data["standard_deviations"]
+    measured_data = calibration_data["measured_data"]
 
     for i in range(16):
-        x_data = np.median(calibration_data['od90'][i], axis = 1)
-        y_data = np.median(calibration_data['od135'][i], axis = 1)
-        z_data = np.array(input_data)
+        paramsig, paramlin = curve_fit(sigmoid, measured_data[i], medians[i], p0 = [62721, 62721, 0, -1], maxfev=1000000000)
+        coefficients.append(np.array(paramsig).tolist())
+    print(coefficients)
+
+    if graph:
+        graph_2d_data(sigmoid, measured_data, medians, standard_deviations, coefficients, fit_name, 'sigmoid', 0, max([max(sublist) for sublist in measured_data]), 500)
+    return create_fit(coefficients, fit_name, "sigmoid", time.time(), params)
+
+def linear_fit(calibration, fit_name, params, graph = True):
+    coefficients = []
+
+    # For single param calibrations, just take the first value from the returned dictionary
+    print(calibration)
+    calibration_data = list(process_vial_data(calibration, param = params[0]).values())[0]
+    medians = calibration_data["medians"]
+    standard_deviations = calibration_data["standard_deviations"]
+    measured_data = calibration_data["measured_data"]
+
+    for i in range(16):
+        print(measured_data[i])
+        print(medians[i])
+        paramlin, cov = curve_fit(linear, medians[i], measured_data[i])
+        coefficients.append(paramlin.tolist())
+
+    if graph:
+        graph_2d_data(linear, medians, measured_data, standard_deviations, coefficients, fit_name, 'linear', 500, 3000, 50)
+
+    return create_fit(coefficients, fit_name, "linear", time.time(), params)
+
+def constant_fit(calibration, fit_name, params):
+    calibration_data = process_vial_data(calibration, param = params[0]).values()[0]
+    measured_data = calibration_data["measured_data"]
+    return create_fit(coefficients, fit_name, "constant", time.time(), params)
+
+def three_dimension_fit(calibration, fit_name, params, graph = True):
+    initial_parameters = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    coefficients = []
+    datas = []
+    calibration_data = process_vial_data(calibration)
+
+    for param, param_data in calibration_data.items():
+        if param == params[0]:
+            x_datas = param_data['medians']
+        elif param == params[1]:
+            y_datas = param_data['medians']
+        z_datas = param_data['measured_data']
+
+    for i in range(16):
+        x_data = np.array(x_datas[i])
+        y_data = np.array(y_datas[i])
+        z_data = np.array(z_datas[i])
 
         data = [x_data, y_data, z_data]
 
         fitted_parameters, pcov = scipy.optimize.curve_fit(three_dim, [x_data, y_data], z_data, p0 = initial_parameters)
-        if graph:
-            SurfacePlot(three_dim, data, fitted_parameters, i, fig1)
 
         modelPredictions = three_dim(data, *fitted_parameters)
-
         absError = modelPredictions - z_data
-
         SE = np.square(absError) # squared errors
         MSE = np.mean(SE) # mean squared errors
         RMSE = np.sqrt(MSE) # Root Mean Squared Error, RMSE
@@ -193,48 +137,93 @@ def calibrate3d_od(calibration_data, graph_name, graph= False):
         print('R-squared:', Rsquared)
         print('fitted prameters', fitted_parameters)
 
-        paramlist.append(fitted_parameters.tolist())
+        coefficients.append(fitted_parameters.tolist())
+        datas.append(data)
 
     if graph:
-        plt.show()
+        graph_3d_data(three_dim, datas, coefficients, fit_name)
 
-    return paramlist
+    return create_fit(coefficients, fit_name, '3d', time.time(), params)
 
-def calibrate_temp(calibration_data, graph_name, graph = False):
-    paramlist = []
-    if graph:
-        fig, ax = plt.subplots(4, 4)
-        fig.suptitle('File Name: ' + graph_name)
+def graph_2d_data(func, measured_data, medians, standard_deviations, coefficients, fit_name, fit_type, space_min, space_max, space_step):
+    linear_space = np.linspace(space_min, space_max, space_step)
+    fig, ax = plt.subplots(4, 4)
+    fig.suptitle("Fit Name: " + fit_name)
+    for i in range(16):
+        ax[i // 4, (i % 4)].plot(measured_data[i], medians[i], 'o', markersize=3, color='black')
+        ax[i //4, (i % 4)].errorbar(measured_data[i], medians[i], yerr=standard_deviations[i], fmt='none')
+        ax[i // 4, (i % 4)].plot(linear_space, func(linear_space, *coefficients[i]), markersize = 1.5, label = None)
+        ax[i // 4, (i % 4)].set_title('Vial: ' + str(i))
+        ax[i // 4, (i % 4)].ticklabel_format(style='sci', axis='y', scilimits=(0,0))
+    plt.subplots_adjust(hspace = 0.6)
+    plt.show()
 
+def graph_3d_data(func, datas, coefficients, fit_name):
+    fig = plt.figure()
+    fig.suptitle("Fit Name: " + fit_name)
+    for i, data in enumerate(datas):
+        x_data = data[0]
+        y_data = data[1]
+        z_data = data[2]
+        x_space = np.linspace(min(x_data), max(x_data), 20)
+        y_space= np.linspace(min(y_data), max(y_data), 20)
+        X, Y = np.meshgrid(x_space, y_space)
+        Z = func(np.array([X, Y]), *coefficients[i])
 
-    ave_temps = []
-    stds = []
-    entered_values = []
+        ax = fig.add_subplot(4, 4, i + 1, projection = '3d')
 
-    for temp_measurement in calibration_data:
-        for i, vial in enumerate(temp_measurement['temp']):
-            if len(ave_temps) == i:
-                ave_temps.append([])
-                stds.append([])
-                entered_values.append([])
-            ave_temps[i].append(np.mean(vial))
-            stds[i].append(np.std(vial))
-            entered_values[i].append(float(temp_measurement['enteredValues'][i]))
+        ax.plot_surface(X, Y, Z, rstride=1, cstride=1, linewidth=1, antialiased=True, alpha=0.5)
 
-    paramlist = []
-    for m in range(16):
-        params, cov = curve_fit(linear, ave_temps[m], entered_values[m])
-        paramlist.append(params.tolist())
-        if graph == True:
-            ax[m//4, (m % 4)].plot(ave_temps[m], entered_values[m], 'o', markersize=3, color='black')
-            ax[m//4, (m % 4)].plot(np.linspace(500, 3000, 50), linear(np.linspace(500,3000,50), *params), markersize = 1.5)
-            ax[m//4, (m % 4)].set_title('Vial: ' + str(m))
+        ax.scatter(x_data, y_data, z_data, c='r', s=10) # show data along with plotted surface
 
-    if graph:
-        plt.subplots_adjust(hspace = 0.6)
-        plt.show()
-    return paramlist
+        ax.set_xlabel('OD90') # X axis data label
+        ax.set_ylabel('OD135') # Y axis data label
+        ax.set_zlabel('OD Measured') # Z axis data label
 
+    plt.show()
+
+def process_vial_data(calibration, param = None):
+    """
+        Data is structed as a list of lists. Each element in the outer list is a vial.
+        That element is also a list, one for each point to be fit. The list contains 1 or more points.
+        This function takes the median of those points and calculates the standard deviation, returning
+        a similar structure.
+
+        [vial0, vial1, vial2, ... ]
+        vial = [point0, point1, point2, ...]
+        point = [replicate0, replicate1, replicate2, ...]
+
+    """
+    raw_sets = calibration.get("raw", None)
+    if raw_sets is None:
+        print("Error processing calibration data - no raw sets found")
+        sys.exit(1)
+
+    calibration_data = {}
+    vial_datas = []
+    names = []
+    for raw_set in raw_sets:
+        if param is None or raw_set.get("param") == param:
+            vial_datas.append(raw_set["vialData"])
+            names.append(raw_set.get("param"))
+
+    for i, vial_data in enumerate(vial_datas):
+        medians = []
+        standard_deviations = []
+        for vial in vial_data:
+            point_medians = []
+            point_standard_deviations = []
+            for point in vial:
+                point_medians.append(np.median(point))
+                point_standard_deviations.append(np.std(point))
+            medians.append(point_medians)
+            standard_deviations.append(point_standard_deviations)
+        calibration_data[names[i]] = {"medians": medians, "standard_deviations": standard_deviations, "measured_data": calibration["measuredData"]}
+
+    return calibration_data
+
+def create_fit(coefficients, fit_name, fit_type, time_fit, params):
+    return {"name": fit_name, "coefficients": coefficients, "type": fit_type, "timeFit": time_fit, "active": False, "params": params}
 
 def start_background_loop(loop):
     asyncio.set_event_loop(loop)
@@ -248,35 +237,27 @@ def run(evolver_ip, evolver_port):
 
 if __name__ == '__main__':
     parser = optparse.OptionParser()
-    parser.add_option('-f', '--cal-file', action = 'store', dest = 'calfile')
-    parser.add_option('-g', '--get-filenames', action = 'store_true', dest = 'getfiles')
-    parser.add_option('-o', '--od', action = 'store_true', dest = 'odcal')
-    parser.add_option('-t', '--temp', action = 'store_true', dest = 'tempcal')
-    parser.add_option('-a', '--ip', action = 'store', dest = 'ipaddress')
-    parser.add_option('--odpower', action = 'store', dest = 'odpower', default='2500')
-    parser.add_option('--odaxis', action = 'store', dest = 'odaxis', default='powerLevel')
-    parser.add_option('--3d', action = 'store_true', dest = 'multidimfit')
-    parser.add_option('--param', action = 'store', dest = 'param')
+    parser.add_option('-n', '--calibration-name', action = 'store', dest = 'calname', help = "Name of the calibration.")
+    parser.add_option('-g', '--get-calibration-names', action = 'store_true', dest = 'getnames', help = "Prints out all calibration names present on the eVOLVER.")
+    parser.add_option('-a', '--ip', action = 'store', dest = 'ipaddress', help = "IP address of eVOLVER")
+    parser.add_option('-t', '--fit-type', action = 'store', dest = 'fittype', help = "Valid options: sigmoid, linear, constant, 3d")
+    parser.add_option('-f', '--fit-name', action = 'store', dest = 'fitname', help = "Desired name for the fit.")
+    parser.add_option('-p', '--params', action = 'store', dest = 'params', help = "Desired parameter(s) to fit. Comma separated, no spaces")
 
 
     (options, args) = parser.parse_args()
-    cal_file = options.calfile
-    get_files = options.getfiles
-    od_cal = options.odcal
-    temp_cal = options.tempcal
-    ip_address = 'http://' + options.ipaddress
-    odpower = options.odpower
-    odaxis = options.odaxis
-    multidimfit = options.multidimfit
-    param = options.param
+    cal_name = options.calname
+    get_names = options.getnames
+    fit_type = options.fittype
+    fit_name = options.fitname
+    params = options.params
 
     if not options.ipaddress:
         print('Please specify ip address')
         parser.print_help()
         sys.exit(2)
 
-    if not param:
-        param = 'od90'
+    ip_address = 'http://' + options.ipaddress
 
     new_loop = asyncio.new_event_loop()
     t = Thread(target = start_background_loop, args = (new_loop,))
@@ -284,41 +265,44 @@ if __name__ == '__main__':
     t.start()
     new_loop.call_soon_threadsafe(run, ip_address, 8081)
 
-    if not od_cal and not temp_cal:
-        print('Please specify od or temperature calibration')
-        parser.print_help()
-        sys.exit(1)
-
     if dpu_evolver_ns is None:
         print("Waiting for evolver connection...")
 
     while dpu_evolver_ns is None:
         pass
 
-    if get_files and od_cal:
-        dpu_evolver_ns.emit('getcalibrationfilenamesod', {}, namespace = '/dpu-evolver')
-    if get_files and temp_cal:
-        dpu_evolver_ns.emit('getcalibrationfilenamestemp', {}, namespace = '/dpu-evolver')
-    if cal_file and od_cal:
-        dpu_evolver_ns.emit('getcalibrationrawod', {'filename':cal_file}, namespace='/dpu-evolver')
-    if cal_file and temp_cal:
-        dpu_evolver_ns.emit('getcalibrationrawtemp', {'filename':cal_file}, namespace = '/dpu-evolver')
+    if get_names:
+        print("Getting calibration names...")
+        dpu_evolver_ns.emit('getcalibrationnames', [], namespace = '/dpu-evolver')
+    if cal_name:
+        if fit_name is None:
+            print("Please input a name for the fit!")
+            parser.print_help()
+            sys.exit(2)
+        if fit_type not in VALID_FIT_TYPES:
+            print("Invalid fit type!")
+            parser.print_help()
+            sys.exit(2)
+        if params is None:
+            print("Must provide at least 1 parameter!")
+            parser.print_help()
+            sys.exit(2)
+        dpu_evolver_ns.emit('getcalibration', {'name':cal_name}, namespace='/dpu-evolver')
+        params = params.strip().split(',')
 
-    while not cal_received:
+    while not data_received:
         pass
 
-    if cal_file is not None and od_cal and not multidimfit:
-        parameters = calibrate_od(raw_calibration, cal_file, param, graph = True)
+    if cal_name is not None and not get_names:
+        if fit_type == "sigmoid":
+            fit = sigmoid_fit(calibration, fit_name, params)
+        elif fit_type == "linear":
+            fit = linear_fit(calibration, fit_name, params)
+        elif fit_type == "constant":
+            fit = constant_fit(calibration, params)
+        elif fit_type == "3d":
+            fit = three_dimension_fit(calibration, fit_name, params)
+
         update_cal = input('Update eVOLVER with calibration? (y/n): ')
         if update_cal == 'y':
-            dpu_evolver_ns.emit('setcalibrationod', {'parameters':parameters, 'filename': cal_file, 'caltype': 'sigmoid'}, namespace='/dpu-evolver')
-    if cal_file is not None and od_cal and multidimfit:
-        parameters = calibrate3d_od(raw_calibration, cal_file, graph = True)
-        update_cal = input('Update eVOLVER with calibration? (y/n): ')
-        if update_cal == 'y':
-            dpu_evolver_ns.emit('setcalibrationod', {'parameters':parameters, 'filename': cal_file, 'caltype': 'multidim_quad'}, namespace='/dpu-evolver')
-    if cal_file is not None and temp_cal:
-        parameters = calibrate_temp(raw_calibration, cal_file, graph = True)
-        update_cal = input('Update eVOLVER with calibration? (y/n): ')
-        if update_cal == 'y':
-            dpu_evolver_ns.emit('setcalibrationtemp', {'parameters':parameters, 'filename': cal_file}, namespace='/dpu-evolver')
+            dpu_evolver_ns.emit('setfitcalibration', {'name': cal_name, 'fit': fit}, namespace = '/dpu-evolver')

--- a/experiment/template/custom_script.py
+++ b/experiment/template/custom_script.py
@@ -26,7 +26,6 @@ STIR_INITIAL = [8] * 16 #try 8,10,12 etc; makes 16-value list
 #STIR_INITIAL = [7,7,7,7,8,8,8,8,9,9,9,9,10,10,10,10]
 
 VOLUME =  25 #mL, determined by vial cap straw length
-OD_POWER = 2125 #must match value used for OD calibration
 PUMP_CAL_FILE = 'pump_cal.txt' #tab delimited, mL/s with 16 influx pumps on first row, etc.
 OPERATION_MODE = 'turbidostat' #use to choose between 'turbidostat' and 'chemostat' functions
 # if using a different mode, name your function as the OPERATION_MODE variable
@@ -34,7 +33,7 @@ OPERATION_MODE = 'turbidostat' #use to choose between 'turbidostat' and 'chemost
 ##### END OF USER DEFINED GENERAL SETTINGS #####
 
 def turbidostat(eVOLVER, input_data, vials, elapsed_time):
-    OD_data = input_data['transformed']['od_90']
+    OD_data = input_data['transformed']['od']
 
     ##### USER DEFINED VARIABLES #####
 

--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -8,11 +8,13 @@ import shutil
 import logging
 import argparse
 import numpy as np
+import json
+import traceback
 from scipy import stats
 from socketIO_client import SocketIO, BaseNamespace
 
 import custom_script
-from custom_script import EXP_NAME, OD_POWER, PUMP_CAL_FILE
+from custom_script import EXP_NAME, PUMP_CAL_FILE
 from custom_script import EVOLVER_IP, EVOLVER_PORT, OPERATION_MODE
 from custom_script import STIR_INITIAL, TEMP_INITIAL
 
@@ -23,6 +25,12 @@ VIALS = [x for x in range(16)]
 
 SAVE_PATH = os.path.dirname(os.path.realpath(__file__))
 EXP_DIR = os.path.join(SAVE_PATH, EXP_NAME)
+OD_CAL_PATH = os.path.join(SAVE_PATH, 'od_cal.json')
+TEMP_CAL_PATH = os.path.join(SAVE_PATH, 'temp_cal.json')
+
+SIGMOID = 'sigmoid'
+LINEAR = 'linear'
+THREE_DIMENSION = '3d'
 
 logger = logging.getLogger('eVOLVER')
 
@@ -56,9 +64,14 @@ class EvolverNamespace(BaseNamespace):
                            'functions')
             return
 
+        with open(OD_CAL_PATH) as f:
+            od_cal = json.load(f)
+        with open(TEMP_CAL_PATH) as f:
+            temp_cal = json.load(f)
+
         # apply calibrations
         # update temperatures if needed
-        data = self.transform_data(data, VIALS)
+        data = self.transform_data(data, VIALS, od_cal, temp_cal)
         if data is None:
             logger.error('could not tranform raw data, skipping user-'
                          'defined functions')
@@ -67,56 +80,63 @@ class EvolverNamespace(BaseNamespace):
         # should we "blank" the OD?
         if self.use_blank and self.OD_initial is None:
             logger.info('setting initial OD reading')
-            self.OD_initial = data['transformed']['od_90']
+            self.OD_initial = data['transformed']['od']
         elif self.OD_initial is None:
             self.OD_initial = np.zeros(len(VIALS))
-        data['transformed']['od_90'] = (data['transformed']['od_90'] -
+        data['transformed']['od'] = (data['transformed']['od'] -
                                         self.OD_initial)
         # save data
-        self.save_data(data['transformed']['od_90'], elapsed_time,
+        self.save_data(data['transformed']['od'], elapsed_time,
                         VIALS, 'OD')
         self.save_data(data['transformed']['temp'], elapsed_time,
                         VIALS, 'temp')
-        self.save_data(data['data'].get('od_90', []), elapsed_time,
-                        VIALS, 'OD90_raw')
-        self.save_data(data['data'].get('od_135', []), elapsed_time,
-                        VIALS, 'OD135_raw')
+
+        for param in od_cal['params']:
+            self.save_data(data['data'].get(param, []), elapsed_time,
+                        VIALS, param + '_raw')
+        for param in temp_cal['params']:
+            self.save_data(data['data'].get(param, []), elapsed_time,
+                        VIALS, param + '_raw')
         # run custom functions
         self.custom_functions(data, VIALS, elapsed_time)
         # save variables
         self.save_variables(self.start_time, self.OD_initial)
 
-    def on_calibrationod(self, data):
-        file_path = os.path.join(EXP_DIR, 'od_cal.txt')
-        with open(file_path, 'w') as f:
-            f.write(data)
-        logger.debug("OD calibration: %s" % data)
+    def on_activecalibrations(self, data):
+        print('Calibrations recieved')
+        for calibration in data:
+            if calibration['calibrationType'] == 'od':
+                file_path = OD_CAL_PATH
+            elif calibration['calibrationType'] == 'temperature':
+                file_path = TEMP_CAL_PATH
+            else:
+                continue
+            for fit in calibration['fits']:
+                if fit['active']:
+                    with open(file_path, 'w') as f:
+                        json.dump(fit, f)
+                    # Create raw data directories and files for params needed
+                    for param in fit['params']:
+                        if not os.path.isdir(os.path.join(EXP_DIR, param + '_raw')):
+                            os.makedirs(os.path.join(EXP_DIR, param + '_raw'))
+                            for x in range(len(fit['coefficients'])):
+                                exp_str = "Experiment: {0} vial {1}, {2}".format(EXP_NAME,
+                                        x,
+                                        time.strftime("%c"))
+                                self._create_file(x, param + '_raw', defaults=[exp_str])
+                    break
 
-    def on_calibrationtemp(self, data):
-        file_path = os.path.join(EXP_DIR, 'temp_calibration.txt')
-        with open(file_path , 'w') as f:
-            f.write(data)
-        logger.debug("temperature calibration: %s" % data)
-
-    def request_od_calibration(self):
-        logger.debug('requesting OD calibrations')
-        self.emit('getcalibrationod',
+    def request_calibrations(self):
+        logger.debug('requesting active calibrations')
+        self.emit('getactivecal',
                   {}, namespace = '/dpu-evolver')
 
-    def request_temp_calibration(self):
-        logger.debug('requesting temperature calibrations')
-        self.emit('getcalibrationtemp',
-                  {}, namespace = '/dpu-evolver')
+    def transform_data(self, data, vials, od_cal, temp_cal):
+        if od_cal['type'] == THREE_DIMENSION:
+            od_data_2 = data['data'].get(od_cal['params'][1], None)
 
-    def transform_data(self, data, vials):
-        odcal_path = os.path.join(EXP_DIR, 'od_cal.txt')
-        od_cal = np.genfromtxt(odcal_path, delimiter=',')
-
-        tempcal_path = os.path.join(EXP_DIR, 'temp_calibration.txt')
-        temp_cal = np.genfromtxt(tempcal_path, delimiter=',')
-
-        od_data = data['data'].get('od_90', None)
-        temp_data = data['data'].get('temp', None)
+        od_data = data['data'].get(od_cal['params'][0], None)
+        temp_data = data['data'].get(temp_cal['params'][0], None)
         set_temp_data = data['config'].get('temp', {}).get('value', None)
 
         if od_data is None or temp_data is None or set_temp_data is None:
@@ -129,6 +149,8 @@ class EvolverNamespace(BaseNamespace):
             return None
 
         od_data = np.array([float(x) for x in od_data])
+        if od_data_2:
+            od_data_2 = np.array([float(x) for x in od_data_2])
         temp_data = np.array([float(x) for x in temp_data])
         set_temp_data = np.array([float(x) for x in set_temp_data])
 
@@ -139,22 +161,31 @@ class EvolverNamespace(BaseNamespace):
             temp_set_data = np.genfromtxt(file_path, delimiter=',')
             temp_set = temp_set_data[len(temp_set_data)-1][1]
             temps.append(temp_set)
+            od_coefficients = od_cal['coefficients'][x]
+            temp_coefficients = temp_cal['coefficients'][x]
             try:
-                if (od_cal.shape[0] == 4):
+                if od_cal['type'] == SIGMOID:
                     #convert raw photodiode data into ODdata using calibration curve
-                    od_data[x] = np.real(od_cal[2,x] -
-                                        ((np.log10((od_cal[1,x] -
-                                                    od_cal[0,x]) /
+                    od_data[x] = np.real(od_coefficients[2] -
+                                        ((np.log10((od_coefficients[1] -
+                                                    od_coefficients[0]) /
                                                     (float(od_data[x]) -
-                                                    od_cal[0,x])-1)) /
-                                                    od_cal[3,x]))
+                                                    od_coefficients[0])-1)) /
+                                                    od_coefficients[3]))
                     if not np.isfinite(od_data[x]):
                         od_data[x] = 'NaN'
                         logger.debug('OD from vial %d: %s' % (x, od_data[x]))
                     else:
                         logger.debug('OD from vial %d: %.3f' % (x, od_data[x]))
+                elif od_cal['type'] == THREE_DIMENSION:
+                    od_data[x] = np.real(od_coefficients[0] +
+                                        (od_coefficients[1]*od_data[x]) +
+                                        (od_coefficients[2]*od_data_2[x]) +
+                                        (od_coefficients[3]*(od_data[x]**2)) +
+                                        (od_coefficients[4]*od_data[x]*od_data_2[x]) +
+                                        (od_coefficients[5]*(od_data_2[x]**2)))
                 else:
-                    logger.error('OD calibration not formatted correctly')
+                    logger.error('OD calibration not of supported type!')
                     od_data[x] = 'NaN'
             except ValueError:
                 print("OD Read Error")
@@ -162,7 +193,7 @@ class EvolverNamespace(BaseNamespace):
                 od_data[x] = 'NaN'
             try:
                 temp_data[x] = (float(temp_data[x]) *
-                                temp_cal[0][x]) + temp_cal[1][x]
+                                temp_coefficients[0]) + temp_coefficients[1]
                 logger.debug('temperature from vial %d: %.3f' % (x, temp_data[x]))
             except ValueError:
                 print("Temp Read Error")
@@ -171,7 +202,7 @@ class EvolverNamespace(BaseNamespace):
                 temp_data[x]  = 'NaN'
             try:
                 set_temp_data[x] = (float(set_temp_data[x]) *
-                                    temp_cal[0][x]) + temp_cal[1][x]
+                                    temp_coefficients[0]) + temp_coefficients[1]
                 logger.debug('set_temperature from vial %d: %.3f' % (x,
                                                                 set_temp_data[x]))
             except ValueError:
@@ -187,8 +218,9 @@ class EvolverNamespace(BaseNamespace):
         if delta_t > 0.2:
             logger.info('updating temperatures (max. deltaT is %.2f)' %
                         delta_t)
-            raw_temperatures = [str(int((temps[x] - temp_cal[1][x]) /
-                                        temp_cal[0][x]))
+            coefficients = temp_cal['coefficients']
+            raw_temperatures = [str(int((temps[x] - temp_cal['coefficients'][x][1]) /
+                                        temp_cal['coefficients'][x][0]))
                                 for x in vials]
             self.update_temperature(raw_temperatures)
         else:
@@ -203,7 +235,7 @@ class EvolverNamespace(BaseNamespace):
 
         # add a new field in the data dictionary
         data['transformed'] = {}
-        data['transformed']['od_90'] = od_data
+        data['transformed']['od'] = od_data
         data['transformed']['temp'] = temp_data
         return data
 
@@ -308,13 +340,10 @@ class EvolverNamespace(BaseNamespace):
 
             start_time = time.time()
 
-            self.request_od_calibration()
-            self.request_temp_calibration()
+            self.request_calibrations()
 
             logger.debug('creating data directories')
             os.makedirs(os.path.join(EXP_DIR, 'OD'))
-            os.makedirs(os.path.join(EXP_DIR, 'OD90_raw'))
-            os.makedirs(os.path.join(EXP_DIR, 'OD135_raw'))
             os.makedirs(os.path.join(EXP_DIR, 'temp'))
             os.makedirs(os.path.join(EXP_DIR, 'temp_config'))
             os.makedirs(os.path.join(EXP_DIR, 'pump_log'))
@@ -327,8 +356,6 @@ class EvolverNamespace(BaseNamespace):
                                                            time.strftime("%c"))
                 # make OD file
                 self._create_file(x, 'OD', defaults=[exp_str])
-                self._create_file(x, 'OD90_raw', defaults=[exp_str])
-                self._create_file(x, 'OD135_raw', defaults=[exp_str])
                 # make temperature data file
                 self._create_file(x, 'temp')
                 # make temperature configuration file
@@ -390,18 +417,10 @@ class EvolverNamespace(BaseNamespace):
 
     def check_for_calibrations(self):
         result = True
-        odcal_path = os.path.join(EXP_DIR, 'od_cal.txt')
-        tempcal_path = os.path.join(EXP_DIR, 'temp_calibration.txt')
-        if not os.path.exists(odcal_path):
+        if not os.path.exists(OD_CAL_PATH) or not os.path.exists(TEMP_CAL_PATH):
             # log and request again
-            logger.warning('OD calibrations not received yet, requesting again')
-            self.request_od_calibration()
-            result = False
-        if not os.path.exists(tempcal_path):
-            # log and request again
-            logger.warning('temperature calibrations not received yet, '
-                        'requesting again')
-            self.request_temp_calibration()
+            logger.warning('Calibrations not received yet, requesting again')
+            self.request_calibrations()
             result = False
         return result
 
@@ -582,6 +601,7 @@ if __name__ == '__main__':
         except Exception as e:
             logger.critical('exception %s stopped the experiment' % str(e))
             print('error "%s" stopped the experiment' % str(e))
+            traceback.print_exc(file=sys.stdout)
             EVOLVER_NS.stop_exp()
             print('Experiment stopped, goodbye!')
             logger.warning('experiment stopped, goodbye!')


### PR DESCRIPTION
# What? Why?
Allows DPU to work with new calibration formats on the server

Changes proposed in this pull request:
- Calibration script fetches and sends data in correct formats
- Calibration script can work with ANY parameters - doesn't care if it's OD or temp cal, just takes generalized function type to fit.
- Changes to the way the scripts options are parsed
- DPU experiment code updated to work with new formats
- DPU experiment code can handle arbitrary parameters for data needed for a calibration. No hardcoding of `OD_90` or `OD_135` anymore!

# Checks
- [ ] Updated documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
