### PR TITLE
Initialize od cal var to None

### DIFF
--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -132,6 +132,7 @@ class EvolverNamespace(BaseNamespace):
                   {}, namespace = '/dpu-evolver')
 
     def transform_data(self, data, vials, od_cal, temp_cal):
+        od_data_2 = None
         if od_cal['type'] == THREE_DIMENSION:
             od_data_2 = data['data'].get(od_cal['params'][1], None)
 


### PR DESCRIPTION
# What? Why?
Quick bugfix for od cal var not being initialized

Changes proposed in this pull request:
- Initialize odcal var to None
# Checks
- [x] Updated documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
