### PR TITLE
Add immediate handles for experimental parameters

### DIFF
--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -240,15 +240,15 @@ class EvolverNamespace(BaseNamespace):
         data['transformed']['temp'] = temp_data
         return data
 
-    def update_stir_rate(self, stir_rates):
+    def update_stir_rate(self, stir_rates, immediate = False):
         data = {'param': 'stir', 'value': stir_rates,
-                'immediate': False, 'recurring': True}
+                'immediate': immediate, 'recurring': True}
         logger.debug('stir rate command: %s' % data)
         self.emit('command', data, namespace = '/dpu-evolver')
 
-    def update_temperature(self, temperatures):
+    def update_temperature(self, temperatures, immediate = False):
         data = {'param': 'temp', 'value': temperatures,
-                'immediate': False, 'recurring': True}
+                'immediate': immediate, 'recurring': True}
         logger.debug('temperature command: %s' % data)
         self.emit('command', data, namespace = '/dpu-evolver')
 
@@ -258,13 +258,13 @@ class EvolverNamespace(BaseNamespace):
                    'recurring': False ,'immediate': True}
         self.emit('command', command, namespace='/dpu-evolver')
 
-    def update_chemo(self, data, vials, bolus_in_s, period_config):
+    def update_chemo(self, data, vials, bolus_in_s, period_config, immediate = False):
         current_pump = data['config']['pump']['value']
 
         MESSAGE = {'fields_expected_incoming': 49,
                    'fields_expected_outgoing': 49,
                    'recurring': True,
-                   'immediate': False,
+                   'immediate': immediate,
                    'value': ['--'] * 48,
                    'param': 'pump'}
 


### PR DESCRIPTION
# What? Why?
Adding the option to make stirring, temperature, chemostat updates immediate. Helpful for any quality control code.

Changes proposed in this pull request:
- Adding an optional boolean input to the function, default (no command given) is defaulted to work with current code.

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
