### PR TITLE
Add media consumption tracking

### DIFF
--- a/graphing/src/cloudevolution/urls.py
+++ b/graphing/src/cloudevolution/urls.py
@@ -27,6 +27,8 @@ urlpatterns = [
 
     url(r'^(?P<experiment>\w+)/(?P<vial>[0-9]+)/$', 'cloudevolution.views.vial_num', name='vial_num'),
 
+    url(r'^(?P<experiment>\w+)/(dilutions)/$', 'cloudevolution.views.dilutions', name='dilutions'),
+
     url(r'^admin/', include(admin.site.urls)),
 ]
 

--- a/graphing/src/cloudevolution/views.py
+++ b/graphing/src/cloudevolution/views.py
@@ -94,7 +94,37 @@ def expt_name(request, experiment):
 
 	return render(request, "experiment.html", context)
 
+def dilutions(request, experiment):
+	sidebar_links, subdir_log = file_scan('expt')
+	vial_count = range(0, 16)
+	expt_dir, expt_subdir = file_scan(experiment)
+	rootdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+	evolver_dir = rootdir + '/experiment'
+	pump_cal = evolver_dir + "/%s/pump_cal.txt" % (expt_subdir[0])
 
+	cal = np.genfromtxt(pump_cal, delimiter="\t")
+	diluted = []
+
+	for vial in vial_count:
+		pump_dir = evolver_dir + "/%s/%s/pump_log/vial%s_pump_log.txt" % (expt_subdir[0], experiment, vial)
+		data = np.genfromtxt(pump_dir, delimiter=',', skip_header=2)
+		if len(data) != 0:
+			volume = str(round(sum(data[:, 1]) * cal[0, vial] / 1000, 2))
+
+		else:
+			volume = 0
+
+		diluted.append(volume)
+		# TODO: get time of last dilution (global or per vial)
+
+		context = {
+		"sidebar_links": sidebar_links,
+		"experiment": experiment,
+		"vial_count": vial_count,
+		"diluted": diluted
+		}
+
+	return render(request, "dilutions.html", context)
 
 
 def file_scan(tag):

--- a/graphing/src/cloudevolution/views.py
+++ b/graphing/src/cloudevolution/views.py
@@ -118,8 +118,12 @@ def dilutions(request, experiment):
 			volume = str(round(sum(data[:, 1]) * cal[0, vial] / 1000, 2))
 
 			dil_intervals = len(np.genfromtxt(ODset_dir, delimiter=",", skip_header=2)) / 2
-			extra_dils = dil_triggered - dil_intervals
-			vial_eff = (dil_intervals - extra_dils) / dil_intervals * 100
+			if dil_intervals != 0:
+				extra_dils = dil_triggered - dil_intervals
+				vial_eff = (dil_intervals - extra_dils) / dil_intervals * 100
+			else:
+				# Experiment is chemostat or vial is not used
+				vial_eff = 0
 
 		else:
 			volume = 0
@@ -129,8 +133,11 @@ def dilutions(request, experiment):
 		efficiency.append(str(round(vial_eff, 1)))
 		last.append(time.ctime(os.path.getmtime(pump_dir)))
 
-	print(last)
 	last_dilution = max(last)
+
+	if efficiency == ['0']*16:
+		# All vials were chemostats or not used
+		efficiency = None
 
 	context = {
 	"sidebar_links": sidebar_links,

--- a/graphing/src/cloudevolution/views.py
+++ b/graphing/src/cloudevolution/views.py
@@ -33,9 +33,9 @@ def vial_num(request, experiment, vial):
 	vial_count = range(0, 16)
 	expt_dir, expt_subdir = file_scan(experiment)
 	rootdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-	evolver_dir = rootdir + '/experiment'
-	OD_dir = evolver_dir + "/%s/%s/OD/vial%s_OD.txt" % (expt_subdir[0],experiment,vial)
-	temp_dir = evolver_dir + "/%s/%s/temp/vial%s_temp.txt" % (expt_subdir[0],experiment,vial)
+	evolver_dir = os.path.join(rootdir, 'experiment')
+	OD_dir = os.path.join(evolver_dir, expt_subdir[0], experiment, "OD", "vial{0}_OD.txt".format(vial))
+	temp_dir = os.path.join(evolver_dir, expt_subdir[0], experiment, "temp", "vial{0}_temp.txt".format(vial))
 
 
 	with open(OD_dir) as f_in:
@@ -99,8 +99,8 @@ def dilutions(request, experiment):
 	vial_count = range(0, 16)
 	expt_dir, expt_subdir = file_scan(experiment)
 	rootdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-	evolver_dir = rootdir + '/experiment'
-	pump_cal = evolver_dir + "/%s/pump_cal.txt" % (expt_subdir[0])
+	evolver_dir = os.path.join(rootdir, 'experiment')
+	pump_cal = os.path.join(evolver_dir, expt_subdir[0], "pump_cal.txt")
 
 	cal = np.genfromtxt(pump_cal, delimiter="\t")
 	diluted = []
@@ -108,8 +108,8 @@ def dilutions(request, experiment):
 	last = []
 
 	for vial in vial_count:
-		pump_dir = evolver_dir + "/%s/%s/pump_log/vial%s_pump_log.txt" % (expt_subdir[0], experiment, vial)
-		ODset_dir = evolver_dir + "/%s/%s/ODset/vial%s_ODset.txt" % (expt_subdir[0], experiment, vial)
+		pump_dir = os.path.join(evolver_dir, expt_subdir[0], experiment, "pump_log", "vial{0}_pump_log.txt".format(vial))
+		ODset_dir = os.path.join(evolver_dir, expt_subdir[0], experiment, "ODset", "vial{0}_ODset.txt".format(vial))
 		data = np.genfromtxt(pump_dir, delimiter=',', skip_header=2)
 
 		dil_triggered = len(data)
@@ -146,20 +146,20 @@ def dilutions(request, experiment):
 
 def file_scan(tag):
 	rootdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-	evolver_dir = rootdir + '/experiment'
+	evolver_dir = os.path.join(rootdir, "experiment")
 	url_string = '{%s url "home" %s}' % ('%','%')
 
 	sidebar_links =[]
 	subdir_log = []
 
 	for subdir in next(os.walk(evolver_dir))[1]:
-	    subdirname = os.path.join(next(os.walk(evolver_dir))[0], subdir)
+		subdirname = os.path.join(next(os.walk(evolver_dir))[0], subdir)
 
-	    for subsubdir in next(os.walk(subdirname))[1]:
-	        if tag in subsubdir:
-	            #add_string = "<li><a href='http://127.0.0.1:8000/%s'>%s</a></li>" % (subsubdir,subsubdir)
-	            #add_string = "<li><a href='%s'>%s</a></li>" % (url_string,subsubdir)
-	            sidebar_links.append(subsubdir)
-	            subdir_log.append(subdir)
+		for subsubdir in next(os.walk(subdirname))[1]:
+			if tag in subsubdir:
+				#add_string = "<li><a href='%s'>%s</a></li>" % (url_string,subsubdir)
+				sidebar_links.append(subsubdir)
+				subdir_log.append(subdir)
+				subdir_log.append(subdir)
 
 	return sidebar_links,subdir_log

--- a/graphing/src/templates/dilutions.html
+++ b/graphing/src/templates/dilutions.html
@@ -24,7 +24,7 @@
 <br>
 <div>
     <table class="table">
-        <caption>Media consumption (based on dilution)</caption>
+        <caption><b>Media consumption (based on dilution)</b></caption>
         <tr>
             <td><b>Vial 0:</b> {{ diluted.0 }} L</td>
             <td><b>Vial 1:</b> {{ diluted.1 }} L</td>
@@ -52,7 +52,38 @@
     </table>
 </div>
 
-<p> Last dilution Value Calculated:  </p> <!--TODO-->
+<div>
+    <table class="table">
+        <caption><b>Dilution efficiency (% of direct dilutions)</b></caption>
+        <tr>
+            <td><b>Vial 0:</b> {{ efficiency.0 }}%</td>
+            <td><b>Vial 1:</b> {{ efficiency.1 }}%</td>
+            <td><b>Vial 2:</b> {{ efficiency.2 }}%</td>
+            <td><b>Vial 3:</b> {{ efficiency.3 }}%</td>
+        </tr>
+            <tr>
+            <td><b>Vial 4:</b> {{ efficiency.4 }}%</td>
+            <td><b>Vial 5:</b> {{ efficiency.5 }}%</td>
+            <td><b>Vial 6:</b> {{ efficiency.6 }}%</td>
+            <td><b>Vial 7:</b> {{ efficiency.7 }}%</td>
+        </tr>
+            <tr>
+            <td><b>Vial 8:</b> {{ efficiency.8 }}%</td>
+            <td><b>Vial 9:</b> {{ efficiency.9 }}%</td>
+            <td><b>Vial 10:</b> {{ efficiency.10 }}%</td>
+            <td><b>Vial 11:</b> {{ efficiency.11 }}%</td>
+        </tr>
+            <tr>
+            <td><b>Vial 12:</b> {{ efficiency.12 }}%</td>
+            <td><b>Vial 13:</b> {{ efficiency.13 }}%</td>
+            <td><b>Vial 14:</b> {{ efficiency.14 }}%</td>
+            <td><b>Vial 15:</b> {{ efficiency.15 }}%</td>
+        </tr>
+    </table>
+</div>
+
+
+<p> Last dilution: {{ last_dilution }} </p>
 
 </div>
 

--- a/graphing/src/templates/dilutions.html
+++ b/graphing/src/templates/dilutions.html
@@ -17,7 +17,7 @@
 	<a href="{% url 'home' %}{{experiment}}/{{x}}" class="btn btn-default btn">{{x}}</a>
 	{% endfor %}
 
-    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">dil</a>
+    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">Dilutions</a>
 
 </div>
 

--- a/graphing/src/templates/dilutions.html
+++ b/graphing/src/templates/dilutions.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+
+{% block bokeh_script %}
+{% endblock %}
+
+
+
+
+{% block content %}
+
+<div class="row">
+<h3>{{experiment}}: <span class='notbold'>All vials</span></h3>
+
+<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
+	{% for x in vial_count %}
+	<a href="{% url 'home' %}{{experiment}}/{{x}}" class="btn btn-default btn">{{x}}</a>
+	{% endfor %}
+
+    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">dil</a>
+
+</div>
+
+<br>
+<div>
+    <table class="table">
+        <caption>Media consumption (based on dilution)</caption>
+        <tr>
+            <td><b>Vial 0:</b> {{ diluted.0 }} L</td>
+            <td><b>Vial 1:</b> {{ diluted.1 }} L</td>
+            <td><b>Vial 2:</b> {{ diluted.2 }} L</td>
+            <td><b>Vial 3:</b> {{ diluted.3 }} L</td>
+        </tr>
+            <tr>
+            <td><b>Vial 4:</b> {{ diluted.4 }} L</td>
+            <td><b>Vial 5:</b> {{ diluted.5 }} L</td>
+            <td><b>Vial 6:</b> {{ diluted.6 }} L</td>
+            <td><b>Vial 7:</b> {{ diluted.7 }} L</td>
+        </tr>
+            <tr>
+            <td><b>Vial 8:</b> {{ diluted.8 }} L</td>
+            <td><b>Vial 9:</b> {{ diluted.9 }} L</td>
+            <td><b>Vial 10:</b> {{ diluted.10 }} L</td>
+            <td><b>Vial 11:</b> {{ diluted.11 }} L</td>
+        </tr>
+            <tr>
+            <td><b>Vial 12:</b> {{ diluted.12 }} L</td>
+            <td><b>Vial 13:</b> {{ diluted.13 }} L</td>
+            <td><b>Vial 14:</b> {{ diluted.14 }} L</td>
+            <td><b>Vial 15:</b> {{ diluted.15 }} L</td>
+        </tr>
+    </table>
+</div>
+
+<p> Last dilution Value Calculated:  </p> <!--TODO-->
+
+</div>
+
+
+{% endblock%}

--- a/graphing/src/templates/dilutions.html
+++ b/graphing/src/templates/dilutions.html
@@ -31,19 +31,19 @@
             <td><b>Vial 2:</b> {{ diluted.2 }} L</td>
             <td><b>Vial 3:</b> {{ diluted.3 }} L</td>
         </tr>
-            <tr>
+        <tr>
             <td><b>Vial 4:</b> {{ diluted.4 }} L</td>
             <td><b>Vial 5:</b> {{ diluted.5 }} L</td>
             <td><b>Vial 6:</b> {{ diluted.6 }} L</td>
             <td><b>Vial 7:</b> {{ diluted.7 }} L</td>
         </tr>
-            <tr>
+        <tr>
             <td><b>Vial 8:</b> {{ diluted.8 }} L</td>
             <td><b>Vial 9:</b> {{ diluted.9 }} L</td>
             <td><b>Vial 10:</b> {{ diluted.10 }} L</td>
             <td><b>Vial 11:</b> {{ diluted.11 }} L</td>
         </tr>
-            <tr>
+        <tr>
             <td><b>Vial 12:</b> {{ diluted.12 }} L</td>
             <td><b>Vial 13:</b> {{ diluted.13 }} L</td>
             <td><b>Vial 14:</b> {{ diluted.14 }} L</td>
@@ -52,35 +52,44 @@
     </table>
 </div>
 
-<div>
-    <table class="table">
-        <caption><b>Dilution efficiency (% of direct dilutions)</b></caption>
-        <tr>
-            <td><b>Vial 0:</b> {{ efficiency.0 }}%</td>
-            <td><b>Vial 1:</b> {{ efficiency.1 }}%</td>
-            <td><b>Vial 2:</b> {{ efficiency.2 }}%</td>
-            <td><b>Vial 3:</b> {{ efficiency.3 }}%</td>
-        </tr>
+
+{% if efficiency %}
+
+    <div>
+        <table class="table">
+            <caption><b>Dilution efficiency (% of direct dilutions)</b></caption>
             <tr>
-            <td><b>Vial 4:</b> {{ efficiency.4 }}%</td>
-            <td><b>Vial 5:</b> {{ efficiency.5 }}%</td>
-            <td><b>Vial 6:</b> {{ efficiency.6 }}%</td>
-            <td><b>Vial 7:</b> {{ efficiency.7 }}%</td>
-        </tr>
+                <td><b>Vial 0:</b> {{ efficiency.0 }}%</td>
+                <td><b>Vial 1:</b> {{ efficiency.1 }}%</td>
+                <td><b>Vial 2:</b> {{ efficiency.2 }}%</td>
+                <td><b>Vial 3:</b> {{ efficiency.3 }}%</td>
+            </tr>
             <tr>
-            <td><b>Vial 8:</b> {{ efficiency.8 }}%</td>
-            <td><b>Vial 9:</b> {{ efficiency.9 }}%</td>
-            <td><b>Vial 10:</b> {{ efficiency.10 }}%</td>
-            <td><b>Vial 11:</b> {{ efficiency.11 }}%</td>
-        </tr>
+                <td><b>Vial 4:</b> {{ efficiency.4 }}%</td>
+                <td><b>Vial 5:</b> {{ efficiency.5 }}%</td>
+                <td><b>Vial 6:</b> {{ efficiency.6 }}%</td>
+                <td><b>Vial 7:</b> {{ efficiency.7 }}%</td>
+            </tr>
             <tr>
-            <td><b>Vial 12:</b> {{ efficiency.12 }}%</td>
-            <td><b>Vial 13:</b> {{ efficiency.13 }}%</td>
-            <td><b>Vial 14:</b> {{ efficiency.14 }}%</td>
-            <td><b>Vial 15:</b> {{ efficiency.15 }}%</td>
-        </tr>
-    </table>
-</div>
+                <td><b>Vial 8:</b> {{ efficiency.8 }}%</td>
+                <td><b>Vial 9:</b> {{ efficiency.9 }}%</td>
+                <td><b>Vial 10:</b> {{ efficiency.10 }}%</td>
+                <td><b>Vial 11:</b> {{ efficiency.11 }}%</td>
+            </tr>
+            <tr>
+                <td><b>Vial 12:</b> {{ efficiency.12 }}%</td>
+                <td><b>Vial 13:</b> {{ efficiency.13 }}%</td>
+                <td><b>Vial 14:</b> {{ efficiency.14 }}%</td>
+                <td><b>Vial 15:</b> {{ efficiency.15 }}%</td>
+            </tr>
+        </table>
+    </div>
+
+{% else %}
+
+    <p>Efficiency data not available. Are you running a chemostat experiment?</p>
+
+{% endif %}
 
 
 <p> Last dilution: {{ last_dilution }} </p>

--- a/graphing/src/templates/experiment.html
+++ b/graphing/src/templates/experiment.html
@@ -20,6 +20,8 @@
 	<a href="{% url 'home' %}{{experiment}}/{{x}}" class="btn btn-default btn">{{x}}</a>
 	{% endfor %}
 
+    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">dil</a>
+
 </div>
 
 </div>

--- a/graphing/src/templates/experiment.html
+++ b/graphing/src/templates/experiment.html
@@ -20,7 +20,7 @@
 	<a href="{% url 'home' %}{{experiment}}/{{x}}" class="btn btn-default btn">{{x}}</a>
 	{% endfor %}
 
-    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">dil</a>
+    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">Dilutions</a>
 
 </div>
 

--- a/graphing/src/templates/vial.html
+++ b/graphing/src/templates/vial.html
@@ -19,7 +19,7 @@
 	<a href="{% url 'home' %}{{experiment}}/{{x}}" class="btn btn-default btn">{{x}}</a>
 	{% endfor %}
 
-    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">dil</a>
+    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">Dilutions</a>
 
 </div>
 

--- a/graphing/src/templates/vial.html
+++ b/graphing/src/templates/vial.html
@@ -19,6 +19,8 @@
 	<a href="{% url 'home' %}{{experiment}}/{{x}}" class="btn btn-default btn">{{x}}</a>
 	{% endfor %}
 
+    <a href="{% url 'home' %}{{experiment}}/dilutions" class="btn btn-default btn">dil</a>
+
 </div>
 
 {{OD_div|safe}}


### PR DESCRIPTION
# What? Why?

Modify the graphing tool to calculate and include information about media consumption.

Changes proposed in this pull request:
- Calculate media consumption and pump efficiency* in `views.py`
- Add html template with data tables (`dilutions.html`)
- Modify navbar in other templates and create url rule to access `dilutions.html`

NOTE: Pump efficiency is the percentage of dilutions that manage to lower OD down to the threshold and don't trigger a second dilution. May be useful to notice pump malfunction or poor OD/pump calibration (see screenshot, pump for vial 2 was sliding on the metal bar)

TODO: Allow user to set a time range to calculate data. Consumption data is mostly interesting for the current media bottle, maybe not the whole experiment.

# Checks
- [ ] Updated documentation.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
![Screen Shot 2020-04-30 at 21 03 05](https://user-images.githubusercontent.com/10668217/80748991-196fd900-8b26-11ea-8293-96644638b969.png)
