### PR TITLE
Add growth rate plot

### DIFF
--- a/graphing/src/cloudevolution/views.py
+++ b/graphing/src/cloudevolution/views.py
@@ -9,7 +9,6 @@ import os
 import time
 import math
 
-
 # Create your views here.
 def home(request):
 	sidebar_links, subdir_log = file_scan('expt')
@@ -68,6 +67,14 @@ def vial_num(request, experiment, vial):
 	gr_data = np.genfromtxt(gr_dir, delimiter=',', skip_header=2)
 
 	last_grate_update = time.ctime(os.path.getmtime(gr_dir))
+
+	# Quick patch when there's not enough growth rate values
+	if gr_data.ndim < 2 or len(gr_data) <= 2:
+		gr_data = np.asarray([[0, 0]])  # Avoids exception in p.line(gr.data ...)
+		last_grate_update = "Not enough OD data yet!"  # Change time for a warning
+	else:
+		# Chop out first gr value, biased by the diff between the initial OD and the lower_thresh
+		gr_data = gr_data[1:]
 
 	p = figure(plot_width=700, plot_height=400)
 	p.y_range = Range1d(0, 1)  # Customize here y-axis range

--- a/graphing/src/cloudevolution/views.py
+++ b/graphing/src/cloudevolution/views.py
@@ -7,6 +7,8 @@ import numpy as np
 import itertools
 import os
 import time
+import math
+
 
 # Create your views here.
 def home(request):
@@ -18,6 +20,7 @@ def home(request):
 
 	return render(request, "home.html", context)
 
+
 # Create your views here.
 def simple_chart(request):
 	sidebar_links, subdir_log = file_scan('expt')
@@ -28,6 +31,7 @@ def simple_chart(request):
 
 	return render(request, "simple_chart.html", context)
 
+
 def vial_num(request, experiment, vial):
 	sidebar_links, subdir_log = file_scan('expt')
 	vial_count = range(0, 16)
@@ -35,14 +39,17 @@ def vial_num(request, experiment, vial):
 	rootdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 	evolver_dir = os.path.join(rootdir, 'experiment')
 	OD_dir = os.path.join(evolver_dir, expt_subdir[0], experiment, "OD", "vial{0}_OD.txt".format(vial))
+	gr_dir = os.path.join(evolver_dir, expt_subdir[0], experiment, "growthrate", "vial{0}_gr.txt".format(vial))
 	temp_dir = os.path.join(evolver_dir, expt_subdir[0], experiment, "temp", "vial{0}_temp.txt".format(vial))
 
+	"""
+	OD PLOT
+	"""
 
 	with open(OD_dir) as f_in:
 		data = np.genfromtxt(itertools.islice(f_in, 0, None, 5), delimiter=',')
 	if len(data) < 1000:
 		data = np.genfromtxt(OD_dir, delimiter=',')
-
 
 	last_OD_update = time.ctime(os.path.getmtime(OD_dir))
 
@@ -52,6 +59,45 @@ def vial_num(request, experiment, vial):
 	p.yaxis.axis_label = 'Optical Density'
 	p.line(data[:,0], data[:,1], line_width=1)
 	OD_script, OD_div = components(p)
+	od_x_range = p.x_range  # Save plot size for later
+
+	"""
+	GROWTH RATE PLOT
+	"""
+
+	gr_data = np.genfromtxt(gr_dir, delimiter=',', skip_header=2)
+
+	last_grate_update = time.ctime(os.path.getmtime(gr_dir))
+
+	p = figure(plot_width=700, plot_height=400)
+	p.y_range = Range1d(0, 1)  # Customize here y-axis range
+	p.x_range = od_x_range  # Set same size as the OD plot
+	p.xaxis.axis_label = 'Hours'
+	p.yaxis.axis_label = 'Growth rate (1/h)'
+	p.line(gr_data[:, 0], gr_data[:, 1], legend="growth rate")  # Growth rate
+	# p.line(gr_data[:, 0], math.log(2) / gr_data[:, 1], legend="growth rate")  # Generation time
+
+	# Sliding window for average growth rate calculation
+	slide_mean = []
+	wsize = 10  # Customize window size to calculate the mean
+	for i in range(0, len(gr_data[:, 1])):
+		if i - wsize < 0:
+			j = 0  # Allows plotting first incomplete windows
+		else:
+			j = i - wsize
+
+		slide_mean.append(np.nanmean(gr_data[j:i+1, 1]))  # Growth rate
+		# slide_mean.append(np.nanmean(math.log(2) / gr_data[j:i+1, 1]))  # Generation time
+
+	p.line(gr_data[:, 0], slide_mean, legend="{0} values mean".format(wsize), line_width=1, line_color="red")
+
+	p.legend.orientation = "top_right"
+
+	grate_script, grate_div = components(p)
+
+	"""
+	TEMPERATURE PLOT
+	"""
 
 	with open(temp_dir) as f_in:
 		data = np.genfromtxt(itertools.islice(f_in, 0, None, 10), delimiter=',')
@@ -62,6 +108,7 @@ def vial_num(request, experiment, vial):
 
 	p = figure(plot_width=700, plot_height=400)
 	p.y_range = Range1d(25, 45)
+	p.x_range = od_x_range  # Set same size as the OD plot
 	p.xaxis.axis_label = 'Hours'
 	p.yaxis.axis_label = 'Temp (C)'
 	p.line(data[:,0], data[:,1], line_width=1)
@@ -74,13 +121,17 @@ def vial_num(request, experiment, vial):
 		"vial": vial,
 		"OD_script": OD_script,
 		"OD_div": OD_div,
+		"grate_script": grate_script,
+		"grate_div": grate_div,
 		"temp_script": temp_script,
 		"temp_div": temp_div,
 		"last_OD_update": last_OD_update,
+		"last_grate_update": last_grate_update,
 		"last_temp_update": last_temp_update,
 	}
 
 	return render(request, "vial.html", context)
+
 
 def expt_name(request, experiment):
 	sidebar_links, subdir_log = file_scan('expt')
@@ -93,6 +144,7 @@ def expt_name(request, experiment):
 	}
 
 	return render(request, "experiment.html", context)
+
 
 def dilutions(request, experiment):
 	sidebar_links, subdir_log = file_scan('expt')

--- a/graphing/src/templates/vial.html
+++ b/graphing/src/templates/vial.html
@@ -3,6 +3,7 @@
 
 {% block bokeh_script %}
 {{OD_script|safe}}
+{{grate_script|safe}}
 {{temp_script|safe}}
 {% endblock %}
 
@@ -25,6 +26,9 @@
 
 {{OD_div|safe}}
 <p> Last OD Value Recorded: {{last_OD_update}} </p>
+
+{{grate_div|safe}}
+<p> Last Growth Rate Value Calculated: {{last_grate_update}} </p>
 
 {{temp_div|safe}}
 <p> Last Temperature Value Recorded: {{last_temp_update}} </p>


### PR DESCRIPTION
# What? Why?

Changes proposed in this pull request:
- Add a plot of growth rate over time using the data that is already calculated by the evolver and logged on the `experiment/growthrate` folder. The average growth rate is also plotted using a sliding window that can be customized.

- Add an option to plot either growth rate or generation time (commenting lines of code).

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
![Screen Shot 2020-05-05 at 17 26 11](https://user-images.githubusercontent.com/10668217/81083969-8b18a000-8ef5-11ea-99fc-34c384e1d348.png)
