### PR TITLE
Optimize OD file loading

### DIFF
--- a/experiment/template/custom_script.py
+++ b/experiment/template/custom_script.py
@@ -39,6 +39,7 @@ def turbidostat(eVOLVER, input_data, vials, elapsed_time):
 
     turbidostat_vials = vials #vials is all 16, can set to different range (ex. [0,1,2,3]) to only trigger tstat on those vials
     stop_after_n_curves = np.inf #set to np.inf to never stop, or integer value to stop diluting after certain number of growth curves
+    OD_values_to_average = 6  # Number of values to calculate the OD average
 
     lower_thresh = [0.2] * len(vials) #to set all vials to the same value, creates 16-value list
     upper_thresh = [0.4] * len(vials) #to set all vials to the same value, creates 16-value list
@@ -81,18 +82,17 @@ def turbidostat(eVOLVER, input_data, vials, elapsed_time):
 
         file_name =  "vial{0}_OD.txt".format(x)
         OD_path = os.path.join(save_path, EXP_NAME, 'OD', file_name)
-        data = np.genfromtxt(OD_path, delimiter=',')
+        #data = np.genfromtxt(OD_path, delimiter=',')
+        data = eVOLVER.tail_to_np(OD_path, OD_values_to_average)
         average_OD = 0
 
         # Determine whether turbidostat dilutions are needed
-        enough_ODdata = (len(data) > 7) #logical, checks to see if enough data points (couple minutes) for sliding window
+        #enough_ODdata = (len(data) > 7) #logical, checks to see if enough data points (couple minutes) for sliding window
         collecting_more_curves = (num_curves <= (stop_after_n_curves + 2)) #logical, checks to see if enough growth curves have happened
 
-        if enough_ODdata:
+        if data.size != 0:
             # Take median to avoid outlier
-            od_values_from_file = []
-            for n in range(1,7):
-                od_values_from_file.append(data[len(data)-n][1])
+            od_values_from_file = data[:,1]
             average_OD = float(np.median(od_values_from_file))
 
             #if recently exceeded upper threshold, note end of growth curve in ODset, allow dilutions to occur and growthrate to be measured
@@ -160,6 +160,8 @@ def chemostat(eVOLVER, input_data, vials, elapsed_time):
     start_time = 0 #hours, set 0 to start immediately
     # Note that script uses AND logic, so both start time and start OD must be surpassed
 
+    OD_values_to_average = 6  # Number of values to calculate the OD average
+
     chemostat_vials = vials #vials is all 16, can set to different range (ex. [0,1,2,3]) to only trigger tstat on those vials
 
     rate_config = [0.5] * 16 #to set all vials to the same value, creates 16-value list
@@ -193,16 +195,15 @@ def chemostat(eVOLVER, input_data, vials, elapsed_time):
         #initialize OD and find OD path
         file_name =  "vial{0}_OD.txt".format(x)
         OD_path = os.path.join(save_path, EXP_NAME, 'OD', file_name)
-        data = np.genfromtxt(OD_path, delimiter=',')
+        #data = np.genfromtxt(OD_path, delimiter=',')
+        data = eVOLVER.tail_to_np(OD_path, OD_values_to_average)
         average_OD = 0
-        enough_ODdata = (len(data) > 7) #logical, checks to see if enough data points (couple minutes) for sliding window
+        #enough_ODdata = (len(data) > 7) #logical, checks to see if enough data points (couple minutes) for sliding window
 
-        if enough_ODdata: #waits for seven OD measurements (couple minutes) for sliding window
+        if data.size != 0: #waits for seven OD measurements (couple minutes) for sliding window
 
             #calculate median OD
-            od_values_from_file = []
-            for n in range(1, 7):
-                od_values_from_file.append(data[len(data)-n][1])
+            od_values_from_file = data[:,1]
             average_OD = float(np.median(od_values_from_file))
 
             # set chemostat config path and pull current state from file

--- a/experiment/template/custom_script.py
+++ b/experiment/template/custom_script.py
@@ -82,7 +82,6 @@ def turbidostat(eVOLVER, input_data, vials, elapsed_time):
 
         file_name =  "vial{0}_OD.txt".format(x)
         OD_path = os.path.join(save_path, EXP_NAME, 'OD', file_name)
-        #data = np.genfromtxt(OD_path, delimiter=',')
         data = eVOLVER.tail_to_np(OD_path, OD_values_to_average)
         average_OD = 0
 
@@ -161,7 +160,6 @@ def chemostat(eVOLVER, input_data, vials, elapsed_time):
     # Note that script uses AND logic, so both start time and start OD must be surpassed
 
     OD_values_to_average = 6  # Number of values to calculate the OD average
-
     chemostat_vials = vials #vials is all 16, can set to different range (ex. [0,1,2,3]) to only trigger tstat on those vials
 
     rate_config = [0.5] * 16 #to set all vials to the same value, creates 16-value list
@@ -195,7 +193,6 @@ def chemostat(eVOLVER, input_data, vials, elapsed_time):
         #initialize OD and find OD path
         file_name =  "vial{0}_OD.txt".format(x)
         OD_path = os.path.join(save_path, EXP_NAME, 'OD', file_name)
-        #data = np.genfromtxt(OD_path, delimiter=',')
         data = eVOLVER.tail_to_np(OD_path, OD_values_to_average)
         average_OD = 0
         #enough_ODdata = (len(data) > 7) #logical, checks to see if enough data points (couple minutes) for sliding window

--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -487,19 +487,19 @@ class EvolverNamespace(BaseNamespace):
         if window == 0:
             return []
 
-        BUFSIZ = 1024
-        f.seek(0, 2)
+        BUFFER_SIZE = 1024
+        f.seek(0, os.SEEK_END)
         remaining_bytes = f.tell()
         size = window + 1
         block = -1
         data = []
 
         while size > 0 and remaining_bytes > 0:
-            if remaining_bytes - BUFSIZ > 0:
+            if remaining_bytes - BUFFER_SIZE > 0:
                 # Seek back one whole BUFSIZ
-                f.seek(block * BUFSIZ, 2)
+                f.seek(block * BUFFER_SIZE, 2)
                 # read BUFFER
-                bunch = f.read(BUFSIZ)
+                bunch = f.read(BUFFER_SIZE)
             else:
                 # file too small, start from beginning
                 f.seek(0, 0)
@@ -507,12 +507,12 @@ class EvolverNamespace(BaseNamespace):
                 bunch = f.read(remaining_bytes)
 
             bunch = bunch.decode('utf-8')
-            data.insert(0, bunch)
+            data.append(bunch)
             size -= bunch.count('\n')
-            remaining_bytes -= BUFSIZ
+            remaining_bytes -= BUFFER_SIZE
             block -= 1
 
-        data = ''.join(data).splitlines()[-window:]
+        data = ''.join(reversed(data)).splitlines()[-window:]
 
         if len(data) < window:
             # Not enough data

--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -482,22 +482,25 @@ class EvolverNamespace(BaseNamespace):
         text_file.write("{0},{1}\n".format(elapsed_time, slope))
         text_file.close()
 
-    def tail_to_np(self, path, window=10):
+    def tail_to_np(self, path, window=10, BUFFER_SIZE=512):
+        """
+        Reads file from the end and returns a numpy array with the data of the last 'window' lines.
+        Alternative to np.genfromtxt(path) by loading only the needed lines instead of the whole file.
+        """
         f = open(path, 'rb')
         if window == 0:
             return []
 
-        BUFFER_SIZE = 1024
         f.seek(0, os.SEEK_END)
         remaining_bytes = f.tell()
-        size = window + 1
+        size = window + 1  # Read one more line to avoid broken lines
         block = -1
         data = []
 
         while size > 0 and remaining_bytes > 0:
             if remaining_bytes - BUFFER_SIZE > 0:
-                # Seek back one whole BUFSIZ
-                f.seek(block * BUFFER_SIZE, 2)
+                # Seek back one whole BUFFER_SIZE
+                f.seek(block * BUFFER_SIZE, os.SEEK_END)
                 # read BUFFER
                 bunch = f.read(BUFFER_SIZE)
             else:


### PR DESCRIPTION
Implement function similar to linux tail to read only the last OD values
used for dilution logic, instead of loading the whole file. This avoids
buildup of broadcast messages in long experiments with large OD log files.

# What? Why?

Changes proposed in this pull request:
- Include the function `tail_to_np()` in the eVOLVER class. 
- Use `tail.to_np()` instead of  `np.genfromtxt()` when loading OD data for dilution logic

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
