### PR TITLE
Calibrate.py calculates constant coeffs properly

### DIFF
--- a/calibration/calibrate.py
+++ b/calibration/calibrate.py
@@ -100,8 +100,12 @@ def linear_fit(calibration, fit_name, params, graph = True):
     return create_fit(coefficients, fit_name, "linear", time.time(), params)
 
 def constant_fit(calibration, fit_name, params):
-    calibration_data = process_vial_data(calibration, param = params[0]).values()[0]
+    calibration_data = list(process_vial_data(calibration, param = params[0]).values())[0]
     measured_data = calibration_data["measured_data"]
+    coefficients = []
+    for i in range(len(measured_data)):
+        coefficients.append(calibration_data['medians'][i][0]/measured_data[i])
+    print(coefficients)
     return create_fit(coefficients, fit_name, "constant", time.time(), params)
 
 def three_dimension_fit(calibration, fit_name, params, graph = True):
@@ -299,7 +303,7 @@ if __name__ == '__main__':
         elif fit_type == "linear":
             fit = linear_fit(calibration, fit_name, params)
         elif fit_type == "constant":
-            fit = constant_fit(calibration, params)
+            fit = constant_fit(calibration, fit_name, params)
         elif fit_type == "3d":
             fit = three_dimension_fit(calibration, fit_name, params)
 


### PR DESCRIPTION
# What? Why?
Updates the constant fit function to divide the vial data by the measured data from the raw fit. This will enable pump calibrations to be supported in the `calibrations.json` file

Addresses #40 

Changes proposed in this pull request:
- Update `constant_fit()` to properly calc the constant.

![Screen Shot 2021-01-20 at 10 48 40 AM](https://user-images.githubusercontent.com/10240498/105202369-eb954f00-5b0f-11eb-95f3-9b559287a70e.png)

