### PR TITLE
DPU uses json pump calibrations from server

### DIFF
--- a/experiment/template/custom_script.py
+++ b/experiment/template/custom_script.py
@@ -26,7 +26,6 @@ STIR_INITIAL = [8] * 16 #try 8,10,12 etc; makes 16-value list
 #STIR_INITIAL = [7,7,7,7,8,8,8,8,9,9,9,9,10,10,10,10]
 
 VOLUME =  25 #mL, determined by vial cap straw length
-PUMP_CAL_FILE = 'pump_cal.txt' #tab delimited, mL/s with 16 influx pumps on first row, etc.
 OPERATION_MODE = 'turbidostat' #use to choose between 'turbidostat' and 'chemostat' functions
 # if using a different mode, name your function as the OPERATION_MODE variable
 


### PR DESCRIPTION
# What? Why?
The server will now supports pump calibrations, so the DPU should fetch them and use them accordingly.

Changes proposed in this pull request:
- Fetch the pump calibrations and process them along with the temp/od ones
- Use the contents of the json pump cal as opposed to the file lookup.

Addresses #39 
