### PR TITLE
Logging setup happens first, all messages logged

### DIFF
--- a/experiment/template/custom_script.py
+++ b/experiment/template/custom_script.py
@@ -250,3 +250,4 @@ def chemostat(eVOLVER, input_data, vials, elapsed_time):
 
 if __name__ == '__main__':
     print('Please run eVOLVER.py instead')
+    logger.info('Please run eVOLVER.py instead')


### PR DESCRIPTION
# What? Why?
We need to ensure all messages are logged into the log file so that the electron app can display messages to the user.

Addresses #47 

Changes proposed in this pull request:
- Add logging messages where missing / change from debug to info
- Setup logging is the first thing to happen before anything else.

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
