### PR TITLE
eVOLVER IP supplied via command line or params

### DIFF
--- a/experiment/template/custom_script.py
+++ b/experiment/template/custom_script.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 #set new name for each experiment, otherwise files will be overwritten
 EXP_NAME = 'data'
-EVOLVER_IP = '192.168.1.2'
+
+# Port for the eVOLVER connection. You should not need to change this unless you have multiple applications on a single RPi.
 EVOLVER_PORT = 8081
 
 ##### Identify pump calibration files, define initial values for temperature, stirring, volume, power settings


### PR DESCRIPTION
# What? Why?
The eVOLVER IP is now supplied via command line instead of being hard coded, or via the configuration file supplied by the GUI. This is to minimize the need for users to modify code to run basic experiments.

Addresses #50 

Changes proposed in this pull request:
- IP supplied via command line
- Check if the IP is in the conf or cmd line, if not, exit and print usage.