### PR TITLE
Reset logger every broadcast

### DIFF
--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -108,6 +108,10 @@ class EvolverNamespace(BaseNamespace):
         self.custom_functions(data, VIALS, elapsed_time)
         # save variables
         self.save_variables(self.start_time, self.OD_initial)
+        
+        # Restart logging for db/gdrive syncing
+        logging.shutdown()
+        logging.getLogger('eVOLVER')
 
     def on_activecalibrations(self, data):
         print('Calibrations recieved')


### PR DESCRIPTION
# What? Why?
For use of the DPU/GUI experiment manager with Dropbox / Google Drive, it is necessary to release the log file periodically to allow for it to sync. Otherwise DB/GDrive will not update the file on their servers, and subesequently any users monitoring the experiment remotely will not be able to get the updates to this file.

Changes proposed in this pull request:
- in `on_broadcast`, shutdown then restart the logger.