### PR TITLE
Use EXP_NAME from custom for data location

### DIFF
--- a/experiment/template/custom_script.py
+++ b/experiment/template/custom_script.py
@@ -10,8 +10,10 @@ logger = logging.getLogger(__name__)
 
 ##### USER DEFINED GENERAL SETTINGS #####
 
-#set new name for each experiment, otherwise files will be overwritten
-EXP_NAME = 'template_experiment'
+# If using the GUI for data visualization, do not change EXP_NAME!
+# only change if you wish to have multiple data folders within a single
+# directory for a set of scripts
+EXP_NAME = 'data'
 
 # Port for the eVOLVER connection. You should not need to change this unless you have multiple applications on a single RPi.
 EVOLVER_PORT = 8081
@@ -79,14 +81,14 @@ def turbidostat(eVOLVER, input_data, vials, elapsed_time):
         # initialize OD and find OD path
 
         file_name =  "vial{0}_ODset.txt".format(x)
-        ODset_path = os.path.join(eVOLVER.exp_dir, 'ODset', file_name)
+        ODset_path = os.path.join(eVOLVER.exp_dir, EXP_NAME, 'ODset', file_name)
         data = np.genfromtxt(ODset_path, delimiter=',')
         ODset = data[len(data)-1][1]
         ODsettime = data[len(data)-1][0]
         num_curves=len(data)/2;
 
         file_name =  "vial{0}_OD.txt".format(x)
-        OD_path = os.path.join(eVOLVER.exp_dir, 'OD', file_name)
+        OD_path = os.path.join(eVOLVER.exp_dir, EXP_NAME, 'OD', file_name)
         data = eVOLVER.tail_to_np(OD_path, OD_values_to_average)
         average_OD = 0
 
@@ -127,7 +129,7 @@ def turbidostat(eVOLVER, input_data, vials, elapsed_time):
                 time_in = round(time_in, 2)
 
                 file_name =  "vial{0}_pump_log.txt".format(x)
-                file_path = os.path.join(eVOLVER.exp_dir,
+                file_path = os.path.join(eVOLVER.exp_dir, EXP_NAME,
                                          'pump_log', file_name)
                 data = np.genfromtxt(file_path, delimiter=',')
                 last_pump = data[len(data)-1][0]
@@ -139,7 +141,7 @@ def turbidostat(eVOLVER, input_data, vials, elapsed_time):
                     MESSAGE[x + 16] = str(time_in + time_out)
 
                     file_name =  "vial{0}_pump_log.txt".format(x)
-                    file_path = os.path.join(eVOLVER.exp_dir, 'pump_log', file_name)
+                    file_path = os.path.join(eVOLVER.exp_dir, EXP_NAME, 'pump_log', file_name)
 
                     text_file = open(file_path, "a+")
                     text_file.write("{0},{1}\n".format(elapsed_time, time_in))
@@ -203,7 +205,7 @@ def chemostat(eVOLVER, input_data, vials, elapsed_time):
 
         #initialize OD and find OD path
         file_name =  "vial{0}_OD.txt".format(x)
-        OD_path = os.path.join(eVOLVER.exp_dir, 'OD', file_name)
+        OD_path = os.path.join(eVOLVER.exp_dir, EXP_NAME, 'OD', file_name)
         data = eVOLVER.tail_to_np(OD_path, OD_values_to_average)
         average_OD = 0
         #enough_ODdata = (len(data) > 7) #logical, checks to see if enough data points (couple minutes) for sliding window
@@ -216,7 +218,7 @@ def chemostat(eVOLVER, input_data, vials, elapsed_time):
 
             # set chemostat config path and pull current state from file
             file_name =  "vial{0}_chemo_config.txt".format(x)
-            chemoconfig_path = os.path.join(eVOLVER.exp_dir,
+            chemoconfig_path = os.path.join(eVOLVER.exp_dir, EXP_NAME,
                                             'chemo_config', file_name)
             chemo_config = np.genfromtxt(chemoconfig_path, delimiter=',')
             last_chemoset = chemo_config[len(chemo_config)-1][0] #should t=0 initially, changes each time a new command is written to file

--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -25,7 +25,7 @@ from custom_script import STIR_INITIAL, TEMP_INITIAL
 VIALS = [x for x in range(16)]
 
 SAVE_PATH = os.path.dirname(os.path.realpath(__file__))
-EXP_DIR = os.path.join(SAVE_PATH, 'data')
+EXP_DIR = os.path.join(SAVE_PATH, EXP_NAME)
 OD_CAL_PATH = os.path.join(SAVE_PATH, 'od_cal.json')
 TEMP_CAL_PATH = os.path.join(SAVE_PATH, 'temp_cal.json')
 PUMP_CAL_PATH = os.path.join(SAVE_PATH, 'pump_cal.json')
@@ -47,7 +47,7 @@ class EvolverNamespace(BaseNamespace):
     OD_initial = None
     experiment_params = None
     ip_address = None
-    exp_dir = EXP_DIR
+    exp_dir = SAVE_DIR
 
     def on_connect(self, *args):
         print("Connected to eVOLVER as client")


### PR DESCRIPTION
# What? Why?
To maintain backwards compatibility with the old django graphing webapp, we need to allow the users to change the name of the data directory. An issue will be made to modify the old code to be able to work with the new data structure that the GUI uses.

Changes proposed in this pull request:
- change exp_name default back to data
- pass the save_dir along from the eVOVLER object to the custom functions

