### PR TITLE
Change order of dependecies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 scipy>=1.2.1
-bokeh>=2.4.3
 numpy>=1.16.1
 Django==1.8.6
 django-crispy-forms>=1.7.2
 matplotlib>=3.0.2
 socketIO-client>=0.7.2
+bokeh==0.10.0


### PR DESCRIPTION
# What? Why?
The order of dependency installations can cause issues - this places bokeh last for an issue with wheel.
Changes proposed in this pull request:
- Move bokeh to end of requirements.txt
