### PR TITLE
Calibrate initial temperatures

### DIFF
--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -408,11 +408,16 @@ class EvolverNamespace(BaseNamespace):
 
             stir_rate = STIR_INITIAL
             temp_values = TEMP_INITIAL
+
             if self.experiment_params:
                 stir_rate = list(map(lambda x: x['stir'], self.experiment_params['vial_configuration']))
                 temp_values = list(map(lambda x: x['temp'], self.experiment_params['vial_configuration']))
             self.update_stir_rate(stir_rate)
-            self.update_temperature(temp_values)
+            with open(TEMP_CAL_PATH) as f:
+                temp_cal = json.load(f)
+                temp_coefficients = temp_cal['coefficients'][x]
+                raw_temperatures = [str(int((temps[x] - temp_coefficients[x][1]) / temp_coefficients[x][0])) for x in vials]
+                self.update_temperature(raw_temperatures)
 
             if always_yes:
                 exp_blank = 'y'

--- a/experiment/template/eVOLVER.py
+++ b/experiment/template/eVOLVER.py
@@ -415,8 +415,8 @@ class EvolverNamespace(BaseNamespace):
             self.update_stir_rate(stir_rate)
             with open(TEMP_CAL_PATH) as f:
                 temp_cal = json.load(f)
-                temp_coefficients = temp_cal['coefficients'][x]
-                raw_temperatures = [str(int((temps[x] - temp_coefficients[x][1]) / temp_coefficients[x][0])) for x in vials]
+                temp_coefficients = temp_cal['coefficients']
+                raw_temperatures = [str(int((temp_values[x] - temp_coefficients[x][1]) / temp_coefficients[x][0])) for x in vials]
                 self.update_temperature(raw_temperatures)
 
             if always_yes:


### PR DESCRIPTION
# What? Why?
`TEMP_INITIAL` was being set without calibrations being applied
Changes proposed in this pull request:
- Apply cal to temps before updating on start of experiment.

# Checks
- [ ] Updated documentation.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).

# Any screenshots or GIFs?
